### PR TITLE
Create site.xml to enable customization of mvn-site-plugin project re…

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/DECORATION/1.6.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.6.0 http://maven.apache.org/xsd/decoration-1.6.0.xsd">
+  <body>
+    <menu name= "Project Documentation">
+    <item name="Project Information" href="project-info.html" collapse = "true">
+      <item name="Dependencies" href="dependencies.html"/>
+      <item name="Dependency Information " href="dependency-info.html" />
+      <item name="Dependency Management" href="dependency-management.html"/>
+      <item name="Distribution Management" href="distribution-management.html"/>
+      <item name="About" href="index.html"/>
+      <item name="Plugin Management" href="plugin-management.html"/>
+      <item name="Plugins" href="plugins.html"/>
+      <item name="Summary" href="summary.html"/>
+    </item>
+    <item name="Project Reports" href="project-reports.html" collapse = "true">
+      <item name="Cobertura Test Coverage" href="/cobertura/index.html"/>
+      <item name="Checkstyle" href="checkstyle.html"/>
+      <item name="CPD" href="cpd.html"/>
+      <item name="PMD" href="pmd.html"/>
+      <item name="Surefire Report" href="surefire-report.html"/>
+      <item name="Groovydoc" href="gapidocs/index.html"/>
+      <item name="JaCoCo" href="jacoco/index.html"/>
+      <item name="Source Xref" href="xref/index.html"/>
+    </item>
+    </menu>
+  </body>
+</project>


### PR DESCRIPTION
…port generation.

The main goal was to include the gmavenplus based automatic groovydoc generation in the automatized project report creation process for github pages
Groovydoc is now included in index.html sitemap
However project-reports.html overview still details and link to javadocs in apidocs directory