### PR TITLE
Bugfix/#19 incorrect nanopore object

### DIFF
--- a/src/main/groovy/life/qbic/datamodel/datasets/OxfordNanoporeMeasurement.groovy
+++ b/src/main/groovy/life/qbic/datamodel/datasets/OxfordNanoporeMeasurement.groovy
@@ -246,10 +246,10 @@ final class OxfordNanoporeMeasurement {
                 .collect { (it as BarcodedFolder).getSampleCode() }
         pooledSampleIds.each { sampleId ->
             final def map = [
-                    "fast5fail": (folders.get("fast5fail") as DataFolder).getTheChildren().find { (it as BarcodedFolder).getSampleCode() },
-                    "fast5pass": (folders.get("fast5pass") as DataFolder).getTheChildren().find { (it as BarcodedFolder).getSampleCode() },
-                    "fastqpass": (folders.get("fastqpass") as DataFolder).getTheChildren().find { (it as BarcodedFolder).getSampleCode() },
-                    "fastqfail": (folders.get("fastqfail") as DataFolder).getTheChildren().find { (it as BarcodedFolder).getSampleCode() }
+                    "fast5fail": (folders.get("fast5fail") as DataFolder).getTheChildren().find { (it as BarcodedFolder).getSampleCode() == sampleId },
+                    "fast5pass": (folders.get("fast5pass") as DataFolder).getTheChildren().find { (it as BarcodedFolder).getSampleCode() == sampleId },
+                    "fastqpass": (folders.get("fastqpass") as DataFolder).getTheChildren().find { (it as BarcodedFolder).getSampleCode() == sampleId },
+                    "fastqfail": (folders.get("fastqfail") as DataFolder).getTheChildren().find { (it as BarcodedFolder).getSampleCode() == sampleId }
             ]
             result[sampleId] = map
         }

--- a/src/main/groovy/life/qbic/datamodel/datasets/datastructure/files/DataFile.groovy
+++ b/src/main/groovy/life/qbic/datamodel/datasets/datastructure/files/DataFile.groovy
@@ -57,7 +57,7 @@ class DataFile {
 
     @Override
     boolean equals(Object o) {
-        if (o == this) {
+        if (o.is(this)) {
             return true
         }
         if (!(o instanceof DataFile)) {

--- a/src/main/groovy/life/qbic/datamodel/datasets/datastructure/folders/DataFolder.groovy
+++ b/src/main/groovy/life/qbic/datamodel/datasets/datastructure/folders/DataFolder.groovy
@@ -71,7 +71,7 @@ class DataFolder {
 
     @Override
     boolean equals(Object o) {
-        if (o == this) {
+        if (o.is(this)) {
             return true
         }
         if (!(o instanceof DataFolder)) {

--- a/src/test/groovy/life/qbic/datamodel/datasets/datastructure/OxfordNanoporeExperimentSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/datasets/datastructure/OxfordNanoporeExperimentSpec.groovy
@@ -19,9 +19,15 @@ class OxfordNanoporeExperimentSpec extends Specification {
     @Shared
     Map minimalWorkingSimpleDataStructure
 
+    @Shared
+    Map minimalWorkingPooledDataStructure
+
     def setupSpec() {
-        InputStream stream = Thread.currentThread().getContextClassLoader().getResourceAsStream("valid-example.json")
-        minimalWorkingSimpleDataStructure = (Map) new JsonSlurper().parse(stream)
+        InputStream singleSampleStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("valid-example.json")
+        minimalWorkingSimpleDataStructure = (Map) new JsonSlurper().parse(singleSampleStream)
+
+        InputStream pooledSampleStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("valid-example-pooled.json")
+        minimalWorkingPooledDataStructure = (Map) new JsonSlurper().parse(pooledSampleStream)
     }
 
     def "Create simple sample Oxford Nanopore experiment successfully"() {
@@ -35,7 +41,22 @@ class OxfordNanoporeExperimentSpec extends Specification {
         then:
         assert experiment.sampleCode == "QABCD001AB"
         assert measurements.size() == 1
+    }
+
+    def "Create a simple pooled Oxford Nanopore experiment successfully"() {
+        given:
+        final def example = minimalWorkingPooledDataStructure
+
+        when:
+        final def experiment = OxfordNanoporeExperiment.create(example)
+        final def measurements = experiment.getMeasurements()
+
+        then:
+        assert experiment.sampleCode == "QABCD001AB"
+        assert measurements.size() == 1
         assert measurements.get(0).logFiles.size() == 8
+        // two samples in measurement
+        assert measurements.get(0).getRawDataPerSample(experiment).keySet().size() == 2
 
     }
 }

--- a/src/test/groovy/life/qbic/datamodel/datasets/datastructure/OxfordNanoporeMeasurementSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/datasets/datastructure/OxfordNanoporeMeasurementSpec.groovy
@@ -114,6 +114,10 @@ class OxfordNanoporeMeasurementSpec extends Specification {
         assert result.size() == 2
         assert result.get("QTEST001AE").get("fast5fail") instanceof DataFolder
         assert result.get("QD00M001AE").get("fast5fail") instanceof DataFolder
+        assert result.get("QTEST001AE").get("fast5fail") == result.get("QTEST001AE").get("fast5fail")
+        assert result.get("QD00M001AE").get("fast5fail") != result.get("QTEST001AE").get("fast5fail")
+        assert result.get("QTEST001AE").get("fast5pass") == result.get("QTEST001AE").get("fast5pass")
+        assert result.get("QD00M001AE").get("fast5pass") != result.get("QTEST001AE").get("fast5pass")
     }
 
     def "incomplete metadata should throw an IllegalArgumentException"() {

--- a/src/test/resources/valid-example-pooled.json
+++ b/src/test/resources/valid-example-pooled.json
@@ -1,0 +1,337 @@
+{
+  "name": "QABCD001AB_E12A345a01_PAE12345",
+  "path": "./",
+  "children": [
+    {
+      "name": "20200122_1217_1-A1-B1-PAE12345_1234567a",
+      "metadata":  {
+        "adapter": "flongle",
+        "asic_temp": "32.631687",
+        "base_caller": "Guppy",
+        "base_caller_version": "3.2.8+bd67289",
+        "device_type" : "promethion",
+        "flow_cell_id": "PAE26306",
+        "flow_cell_product_code": "FLO-PRO002",
+        "flow_cell_position": "2-A3-D3",
+        "hostname": "PCT0094",
+        "protocol": "sequencing/sequencing_PRO002_DNA:FLO-PRO002:SQK-LSK109:True",
+        "started": "2020-02-11T15:52:10.465982+01:00"
+      },
+      "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a",
+      "children": [
+        {
+          "name": "throughput_.csv",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/throughput_.csv",
+          "file_type": "csv"
+        },
+        {
+          "name": "report_.md",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/report_.md",
+          "file_type": "md"
+        },
+        {
+          "name": "final_summary_.txt",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/final_summary_.txt",
+          "file_type": "txt"
+        },
+        {
+          "name": "fastq_pass",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass",
+          "children": [
+            {
+              "name": "QABCD001AB",
+              "path": "20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/QABCD001AB",
+              "children": [
+                {
+                  "name": "myfile3.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/QABCD001AB/myfile3.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile2.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/QABCD001AB/myfile2.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile4.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/QABCD001AB/myfile4.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile5.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/QABCD001AB/myfile5.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile1.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/QABCD001AB/myfile1.fastq.gz",
+                  "file_type": "fastq.gz"
+                }
+              ]
+            },
+            {
+              "name": "QABCD002CD",
+              "path": "20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/QABCD002CD",
+              "children": [
+                {
+                  "name": "myfile3.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/QABCD002CD/myfile3.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile2.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/QABCD002CD/myfile2.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile4.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/QABCD002CD/myfile4.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile5.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/QABCD002CD/myfile5.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile1.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/QABCD002CD/myfile1.fastq.gz",
+                  "file_type": "fastq.gz"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "fastq_fail",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail",
+          "children": [
+            {
+              "name": "QABCD001AB",
+              "path": "20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/QABCD001AB",
+              "children": [
+                {
+                  "name": "myfile3.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/QABCD001AB/myfile3.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile2.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/QABCD001AB/myfile2.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile4.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/QABCD001AB/myfile4.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile5.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/QABCD001AB/myfile5.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile1.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/QABCD001AB/myfile1.fastq.gz",
+                  "file_type": "fastq.gz"
+                }
+              ]
+            },
+            {
+              "name": "QABCD002CD",
+              "path": "20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/QABCD002CD",
+              "children": [
+                {
+                  "name": "myfile3.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/QABCD002CD/myfile3.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile2.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/QABCD002CD/myfile2.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile4.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/QABCD002CD/myfile4.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile5.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/QABCD002CD/myfile5.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile1.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/QABCD002CD/myfile1.fastq.gz",
+                  "file_type": "fastq.gz"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "duty_time_.csv",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/duty_time_.csv",
+          "file_type": "csv"
+        },
+        {
+          "name": "sequencing_summary_.txt",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/sequencing_summary_.txt",
+          "file_type": "txt"
+        },
+        {
+          "name": "mux_scan_data.csv",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/mux_scan_data.csv",
+          "file_type": "csv"
+        },
+        {
+          "name": "drift_correction_.csv",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/drift_correction_.csv",
+          "file_type": "csv"
+        },
+        {
+          "name": "report_test.pdf",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/report_test.pdf",
+          "file_type": "pdf"
+        },
+        {
+          "name": "fast5_fail",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail",
+          "children": [
+            {
+              "name": "QABCD001AB",
+              "path": "20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/QABCD001AB",
+              "children": [
+                {
+                  "name": "myfile3.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/QABCD001AB/myfile3.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile2.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/QABCD001AB/myfile2.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile4.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/QABCD001AB/myfile4.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile5.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/QABCD001AB/myfile5.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile1.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/QABCD001AB/myfile1.fast5",
+                  "file_type": "fast5"
+                }
+              ]
+            },
+            {
+              "name": "QABCD002CD",
+              "path": "20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/QABCD002CD",
+              "children": [
+                {
+                  "name": "myfile3.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/QABCD002CD/myfile3.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile2.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/QABCD002CD/myfile2.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile4.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/QABCD002CD/myfile4.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile5.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/QABCD002CD/myfile5.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile1.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/QABCD002CD/myfile1.fast5",
+                  "file_type": "fast5"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "fast5_pass",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass",
+          "children": [
+            {
+              "name": "QABCD001AB",
+              "path": "20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/QABCD001AB",
+              "children": [
+                {
+                  "name": "myfile3.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/QABCD001AB/myfile3.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile2.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/QABCD001AB/myfile2.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile4.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/QABCD001AB/myfile4.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile5.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/QABCD001AB/myfile5.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile1.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/QABCD001AB/myfile1.fast5",
+                  "file_type": "fast5"
+                }
+              ]
+            },
+            {
+              "name": "QABCD002CD",
+              "path": "20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/QABCD002CD",
+              "children": [
+                {
+                  "name": "myfile3.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/QABCD002CD/myfile3.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile2.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/QABCD002CD/myfile2.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile4.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/QABCD002CD/myfile4.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile5.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/QABCD002CD/myfile5.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile1.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/QABCD002CD/myfile1.fast5",
+                  "file_type": "fast5"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR has a search and destroy order for #19 

## Observed behaviour
Multiple samples in one measurement were assigned identical DataFolders from one random sample.

## Cause 
When the information on the DataFolder is assigned to a sample the first DataFolder was always chosen.

## Fix
Adjust filtering to filter for the desired sample code