### PR TITLE
Provide access to the measurement adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Changelog for the data model library
 
+## 1.9.2
+
+* Adds missing getter method for the measurement adapter
+
 ## 1.9.1
 
 * Fix for `getRawDataPerSample()`, which failed in the presence of unclassified folders.

--- a/src/main/groovy/life/qbic/datamodel/datasets/OxfordNanoporeMeasurement.groovy
+++ b/src/main/groovy/life/qbic/datamodel/datasets/OxfordNanoporeMeasurement.groovy
@@ -177,6 +177,16 @@ final class OxfordNanoporeMeasurement {
     }
 
     /**
+     * Provides access to the adapter type used in the measurement.
+     *
+     * Is empty when no adapter was used.
+     * @return
+     */
+    String getAdapter() {
+        return metadata.get(METADATA_FIELD.ADAPTER) ?: ""
+    }
+
+    /**
      * Provides access to the asic temperature.
      * @return
      */

--- a/src/test/groovy/life/qbic/datamodel/datasets/datastructure/OxfordNanoporeMeasurementSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/datasets/datastructure/OxfordNanoporeMeasurementSpec.groovy
@@ -86,6 +86,7 @@ class OxfordNanoporeMeasurementSpec extends Specification {
         when:
         def result = measurement.getRawDataPerSample(mockedExperiment)
         def libraryKit = measurement.getLibraryPreparationKit()
+        def adapter = measurement.getAdapter()
 
         then:
         assert result.size() == 1
@@ -95,6 +96,7 @@ class OxfordNanoporeMeasurementSpec extends Specification {
         assert result.get("QABCD001AE").get("fastqpass") instanceof DataFolder
         assert measurement.relativePath == "path/20200219_1107_1-E3-H3_PAE26974_454b8dc6"
         assert libraryKit == "SQK-LSK109"
+        assert adapter.equals("flongle")
     }
 
     def "create pooled sample measurement successfully"() {
@@ -190,6 +192,34 @@ class OxfordNanoporeMeasurementSpec extends Specification {
 
         then:
         thrown(IllegalArgumentException)
+
+    }
+
+    def "missing adapter metadata shall return an empty String and not be null"() {
+        given:
+        def metaData = [
+            "asic_temp": "32.631687",
+            "base_caller": "Guppy",
+            "base_caller_version": "3.2.8+bd67289",
+            "device_type" : "promethion",
+            "flow_cell_id": "PAE26306",
+            "flow_cell_product_code": "FLO-PRO002",
+            "flow_cell_position": "2-A3-D3",
+            "hostname": "PCT0094",
+            "protocol": "sequencing/sequencing_PRO002_DNA:FLO-PRO002:SQK-LSK109:True",
+            "started": "2020-02-11T15:52:10.465982+01:00"
+        ]
+
+        when:
+        final def measurement = OxfordNanoporeMeasurement.create(
+            "20200219_1107_1-E3-H3_PAE26974_454b8dc6",
+            "path/20200219_1107_1-E3-H3_PAE26974_454b8dc6",
+            [fast5FailedFolder, fast5PassedFolder, fastQFailedFolder, fastQPassedFolder],
+            metaData)
+        final def adapter = measurement.getAdapter()
+
+        then:
+        assert adapter.isEmpty()
 
     }
 


### PR DESCRIPTION
This commit allows the client to access the measurement
adapter used in the Oxford Nanopore Measurement.

As the adapter field is an optional metadata property, it will
be an empty String if the field was not set.