### PR TITLE
Reflect illegal states of ON measurements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 		<version>2.2.0</version>
 	</parent>
 	<artifactId>data-model-lib</artifactId>
-	<version>1.9.0-SNAPSHOT</version>
+	<version>1.10.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>Data Model Library</name>
 	<url>http://github.com/qbicsoftware/data-model-lib</url>

--- a/src/main/groovy/life/qbic/datamodel/datasets/OxfordNanoporeMeasurement.groovy
+++ b/src/main/groovy/life/qbic/datamodel/datasets/OxfordNanoporeMeasurement.groovy
@@ -57,6 +57,7 @@ final class OxfordNanoporeMeasurement {
         readMetaData(metadata)
         createContent()
         assessPooledStatus()
+        assessState()
     }
 
     private List<DataFile> getLogFileCollection() {
@@ -78,11 +79,13 @@ final class OxfordNanoporeMeasurement {
     }
 
     private void assessPooledStatus() {
-        this.pooledSamplesMeasurement = folders["fast5pass"] ? folders["fast5pass"].getChildren().get(0) instanceof Fast5Folder : false
+        this.pooledSamplesMeasurement = folders["fast5pass"]?.getChildren() ?
+            folders["fast5pass"].getChildren().get(0) instanceof Fast5Folder : false
         // There can be still pooled samples in the failed folder, worst case is all
         // samples failed, so we need to check there to
         if (! pooledSamplesMeasurement) {
-            this.pooledSamplesMeasurement = folders["fast5fail"] ? folders["fast5fail"].getChildren().get(0) instanceof Fast5Folder : false
+            this.pooledSamplesMeasurement = folders["fast5fail"]?.getChildren() ? folders["fast5fail"]
+                .getChildren().get(0) instanceof Fast5Folder : false
         }
     }
 
@@ -132,6 +135,27 @@ final class OxfordNanoporeMeasurement {
                     logFilesCollection.add(element as DataFile)
                     break
             }
+        }
+    }
+
+    private void assessState() throws IllegalStateException {
+        // Condition one: Don't allow Fast5 pass and fail folder are empty
+        assessFast5Content()
+        // Condition two: Don't allow Fastq pass and fail folder are empty
+        assessFastQContent()
+    }
+
+    private void assessFast5Content() throws IllegalStateException {
+        if (folders["fast5pass"].getChildren().isEmpty() && folders["fast5fail"].getChildren()
+            .isEmpty()) {
+            throw new IllegalStateException("The fast5 pass folder and fail folder are empty.")
+        }
+    }
+
+    private void assessFastQContent() throws IllegalStateException {
+        if (folders["fastqpass"].getChildren().isEmpty() && folders["fastqfail"].getChildren()
+            .isEmpty()) {
+            throw new IllegalStateException("The fastq pass folder and fail folder are empty.")
         }
     }
 

--- a/src/main/resources/schemas/nanopore-instrument-output.schema.json
+++ b/src/main/resources/schemas/nanopore-instrument-output.schema.json
@@ -24,7 +24,7 @@
           "minLength": 1
         },
         "children": {
-          "description": "Describes files and/or sub-folders if existant",
+          "description": "Describes files and/or sub-folders if existent",
           "type": "array",
           "items": {
             "oneOf": [

--- a/src/main/resources/schemas/nanopore-instrument-output.schema.json
+++ b/src/main/resources/schemas/nanopore-instrument-output.schema.json
@@ -24,7 +24,7 @@
           "minLength": 1
         },
         "children": {
-          "description": "Describes one or more files and/or sub-folders",
+          "description": "Describes files and/or sub-folders if existant",
           "type": "array",
           "items": {
             "oneOf": [
@@ -35,8 +35,7 @@
                 "$ref": "#/definitions/file"
               }
             ]
-          },
-          "minItems": 1
+          }
         }
       }
     },
@@ -224,8 +223,7 @@
                     "$ref": "#/definitions/fast5_file"
                   }
                 ]
-              },
-              "minItems": 1
+              }
             }
           }
         }
@@ -254,8 +252,7 @@
                     "$ref": "#/definitions/fast5_file"
                   }
                 ]
-              },
-              "minItems": 1
+              }
             }
           }
         }
@@ -284,8 +281,7 @@
                     "$ref": "#/definitions/fastqgz_file"
                   }
                 ]
-              },
-              "minItems": 1
+              }
             }
           }
         }
@@ -314,8 +310,7 @@
                     "$ref": "#/definitions/fastqgz_file"
                   }
                 ]
-              },
-              "minItems": 1
+              }
             }
           }
         }

--- a/src/test/groovy/life/qbic/datamodel/datasets/datastructure/OxfordNanoporeMeasurementSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/datasets/datastructure/OxfordNanoporeMeasurementSpec.groovy
@@ -148,4 +148,41 @@ class OxfordNanoporeMeasurementSpec extends Specification {
 
     }
 
+
+    def "If both fast5 pass and fail folder are empty, an IllegalStateException shall be thrown"() {
+        given:
+        def emptyfast5FailedFolder = Fast5FailFolder.create("fast5_fail","root/fast5_fail", [])
+        def emptyfast5PassedFolder = Fast5PassFolder.create("fast5_pass","root/fast5_pass", [])
+
+        when:
+        OxfordNanoporeMeasurement.create(
+            "20200219_1107_1-E3-H3_PAE26974_454b8dc6",
+            "path/20200219_1107_1-E3-H3_PAE26974_454b8dc6",
+            [emptyfast5PassedFolder, emptyfast5FailedFolder, fastQPassedFolder, fastQFailedFolder],
+            metaData)
+
+        then:
+        thrown(IllegalStateException)
+
+    }
+
+    def "If both fastq pass and fail folder are empty, an IllegalStateException shall be thrown"() {
+        given:
+        def emptyFastQFailedFolder = FastQFailFolder.create("fastq_fail","root/fastq_fail", [])
+        def emptyFastQPassedFolder = FastQPassFolder.create("fastq_pass","root/fastq_pass", [])
+
+        when:
+        OxfordNanoporeMeasurement.create(
+            "20200219_1107_1-E3-H3_PAE26974_454b8dc6",
+            "path/20200219_1107_1-E3-H3_PAE26974_454b8dc6",
+            [fast5PassedFolder, fast5FailedFolder, emptyFastQFailedFolder, emptyFastQPassedFolder],
+            metaData)
+
+        then:
+        thrown(IllegalStateException)
+
+    }
+
+
+
 }


### PR DESCRIPTION
Fix #31 

As a failsafe and part of our business rule at QBiC,
we must ensure that the pass and fail folder for either
fast5 or fastq are not empty during the creation of
an OxfordNanoporeMeasurement object.

Therefore, if the pass and fail folder are both empty for either
fastq oder fast5, an IllegalStateException will be thrown
during the instanciation of an OxfordNanopreMeasurement object.