### PR TITLE
Refactor #33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.9.4
 
-* Fix implementation of `containsAtLeastOneBarcodedFolder`
+* Fix implementation of `containsAtLeastOneBarcodedFolder`, such that the method checks all child elements to contain at least one barcoded folder in order to flag the measurement as pooled measurement.
 
 ## 1.9.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Changelog for the data model library
 
+## 1.9.4
+
+* Fix implementation of `containsAtLeastOneBarcodedFolder`
+
 ## 1.9.3
 
 * Fix #31

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 		<version>2.2.0</version>
 	</parent>
 	<artifactId>data-model-lib</artifactId>
-	<version>1.9.3</version>
+	<version>1.9.4</version>
 	<packaging>jar</packaging>
 	<name>Data Model Library</name>
 	<url>http://github.com/qbicsoftware/data-model-lib</url>

--- a/src/main/groovy/life/qbic/datamodel/datasets/OxfordNanoporeMeasurement.groovy
+++ b/src/main/groovy/life/qbic/datamodel/datasets/OxfordNanoporeMeasurement.groovy
@@ -91,7 +91,7 @@ final class OxfordNanoporeMeasurement {
         if (!folder) {
             return false
         } else if (folder.getChildren()) {
-            return folder.getChildren().get(0) instanceof Fast5Folder
+            return folder.getChildren().any { it instanceof Fast5Folder }
         }
         return false
     }


### PR DESCRIPTION
Fix #33 

In general, the names of methods and their functionality should
always fit together. This was not given in the current case and
is fixed with this patch.