### PR TITLE
Add accounting data objects

### DIFF
--- a/src/main/groovy/life/qbic/datamodel/accounting/CostEstimate.groovy
+++ b/src/main/groovy/life/qbic/datamodel/accounting/CostEstimate.groovy
@@ -1,0 +1,23 @@
+package life.qbic.datamodel.accounting
+
+import life.qbic.datamodel.persons.Person
+import life.qbic.datamodel.projects.ProjectInfo
+
+/**
+ * A cost estimate for a project
+ *
+ * During project planning a cost estimate is often required to list expected costs.
+ * This estimate is not intended to be legally binding. It provides an overview over the project
+ * scope and the costs associated with it.
+ *
+ * @since: 1.9.0
+ * @author: Tobias Koch
+ *
+ * * */
+class CostEstimate {
+    Date modificationDate
+    Person customer
+    ProjectInfo projectInfo
+    List<CostItem> items
+    double totalPrice
+}

--- a/src/main/groovy/life/qbic/datamodel/accounting/CostEstimate.groovy
+++ b/src/main/groovy/life/qbic/datamodel/accounting/CostEstimate.groovy
@@ -20,4 +20,5 @@ class CostEstimate {
     ProjectInfo projectInfo
     List<CostItem> items
     double totalPrice
+    final String IDENTIFIER
 }

--- a/src/main/groovy/life/qbic/datamodel/accounting/CostItem.groovy
+++ b/src/main/groovy/life/qbic/datamodel/accounting/CostItem.groovy
@@ -12,7 +12,6 @@ package life.qbic.datamodel.accounting
 class CostItem {
 
     double quantity
-    final String IDENTIFIER
     final double UNIT_PRICE
     final String UNIT_NAME
     final String NAME

--- a/src/main/groovy/life/qbic/datamodel/accounting/CostItem.groovy
+++ b/src/main/groovy/life/qbic/datamodel/accounting/CostItem.groovy
@@ -1,0 +1,44 @@
+package life.qbic.datamodel.accounting
+
+/**
+ * An item with associated costs and quantity
+ *
+ * Cost items describe services and their price. They are the building blocks of invoices and offers.
+ * The unit price is always provided in euros.
+ * @since: 1.9.0
+ * @author: Tobias Koch
+ *
+ * * */
+class CostItem {
+
+    double quantity
+    final String IDENTIFIER
+    final double UNIT_PRICE
+    final String UNIT_NAME
+    final String NAME
+    final String DESCRIPTION
+
+    CostItem(double UNIT_PRICE, String UNIT_NAME, String NAME, String DESCRIPTION) {
+        this.UNIT_PRICE = UNIT_PRICE
+        this.UNIT_NAME = UNIT_NAME
+        this.NAME = NAME
+        this.DESCRIPTION = DESCRIPTION
+    }
+
+    CostItem(double quantity, double UNIT_PRICE, String UNIT_NAME, String NAME, String DESCRIPTION) {
+        this.quantity = quantity
+        this.UNIT_PRICE = UNIT_PRICE
+        this.UNIT_NAME = UNIT_NAME
+        this.NAME = NAME
+        this.DESCRIPTION = DESCRIPTION
+    }
+
+    double getQuantity() {
+        return quantity
+    }
+
+    void setQuantity(double quantity) {
+        this.quantity = quantity
+    }
+}
+

--- a/src/main/groovy/life/qbic/datamodel/accounting/Offer.groovy
+++ b/src/main/groovy/life/qbic/datamodel/accounting/Offer.groovy
@@ -1,0 +1,30 @@
+package life.qbic.datamodel.accounting
+
+import life.qbic.datamodel.persons.Person
+import life.qbic.datamodel.projects.ProjectInfo
+
+/**
+ * An offer for a project
+ *
+ * An offer describes a legally binding service proposal with associated costs.
+ *
+ * @since: 1.9.0
+ * @author: Tobias Koch
+ *
+ * * */
+class Offer {
+    Date modificationDate
+    Date expirationDate
+    Person customer
+    Person projectManager
+    ProjectInfo projectInfo
+    List<CostItem> items
+    double totalPrice
+    final String IDENTIFIER
+
+    Offer(String IDENTIFIER) {
+        this.IDENTIFIER = IDENTIFIER
+    }
+}
+
+


### PR DESCRIPTION
## This PR introduces classes to be used in the context of accounting.
### CostItem
 * Cost items describe services and their price. They are the building blocks of invoices and offers.
 * The unit price is always provided in euros.
### CostEstimate
 * During project planning a cost estimate is often required to list expected costs.
 * This estimate is not intended to be legally binding. 
 * It provides an overview of the project scope and the costs associated with it.
### Offer
 * An offer describes a legally binding service proposal with associated costs.
