### PR TITLE
Add business DTO Customer and Affiliation

### DIFF
--- a/src/main/groovy/life/qbic/datamodel/dtos/business/Affiliation.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/Affiliation.groovy
@@ -1,7 +1,5 @@
 package life.qbic.datamodel.dtos.business
 
-import groovy.transform.builder.Builder
-
 /**
  * This class serves as a simple DTO for customer affiliations
  *
@@ -10,18 +8,45 @@ import groovy.transform.builder.Builder
  */
 final class Affiliation {
 
+  /**
+   * The organisation label of an affiliation.
+   *
+   * For example "University of Tübingen"
+   */
   final String organisation
 
+  /**
+   * An optional address addition.
+   *
+   * Like "Quantitative Biology Center"
+   */
   final String addressAddition
 
+  /**
+   * The affiliation street
+   */
   final String street
 
+  /**
+   * The affiliation postal code
+   */
   final String postalCode
 
+  /**
+   * The affiliation city
+   */
   final String city
 
+  /**
+   * The affiliation country. Defaults to "Germany" if not set otherwise in the builder.
+   */
   final String country
 
+  /**
+   * An affiliation category @link{AffiliationCategory}.
+   *
+   * Defaults to 'external non-academic'.
+   */
   final AffiliationCategory category
 
   static class Builder {
@@ -46,7 +71,7 @@ final class Affiliation {
       this.postalCode = postalCode
       this.city = city
       this.addressAddition = ""
-      this.country = ""
+      this.country = "Germany"
       this.category = AffiliationCategory.EXTERNAL
     }
 

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/Affiliation.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/Affiliation.groovy
@@ -1,0 +1,85 @@
+package life.qbic.datamodel.dtos.business
+
+import groovy.transform.builder.Builder
+
+/**
+ * This class serves as a simple DTO for customer affiliations
+ *
+ * @author Sven Fillinger
+ * @since 1.11.0
+ */
+final class Affiliation {
+
+  final String organisation
+
+  final String addressAddition
+
+  final String street
+
+  final String postalCode
+
+  final String city
+
+  final String country
+
+  final AffiliationCategory category
+
+  static class Builder {
+
+    String organisation
+
+    String addressAddition
+
+    String street
+
+    String postalCode
+
+    String city
+
+    String country
+
+    AffiliationCategory category
+
+    Builder(String organisation, String street, String postalCode, String city) {
+      this.organisation = organisation
+      this.street = street
+      this.postalCode = postalCode
+      this.city = city
+      this.addressAddition = ""
+      this.country = ""
+      this.category = AffiliationCategory.EXTERNAL
+    }
+
+    Builder addressAddition(String addressAddition) {
+      this.addressAddition = addressAddition
+      return this
+    }
+
+    Builder country(String country) {
+      this.country = country
+      return this
+    }
+
+    Builder category(AffiliationCategory category) {
+      this.category = category
+      return this
+    }
+
+    Affiliation build() {
+      return new Affiliation(this)
+    }
+
+  }
+
+  private Affiliation(Builder builder) {
+    this.addressAddition = builder.addressAddition
+    this.organisation = builder.organisation
+    this.street = builder.street
+    this.country = builder.country
+    this.postalCode = builder.postalCode
+    this.category = builder.category
+    this.city = builder.city
+  }
+
+
+}

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/AffiliationCategory.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/AffiliationCategory.groovy
@@ -1,0 +1,48 @@
+package life.qbic.datamodel.dtos.business
+
+/**
+ * We define three major business affiliation categories here, which
+ * means that we decide between
+ *  - internal: An affiliation we consider as within the University of Tübingen or University
+ *  Hospital of Tübingen
+ *  - external academic: An outside affiliation but an academic institution (public research
+ *  institutions)
+ *  - external: An outside affiliation but not academic (i.e. private sector, companies, etc)
+ */
+enum AffiliationCategory {
+
+  INTERNAL("internal"),
+  EXTERNAL_ACADEMIC("external academic"),
+  EXTERNAL("external non-academic")
+
+  /**
+   * Holds the value of the enum
+   */
+  private final String value
+
+  /**
+   * Private constructor to create different AffiliationCategory enum items
+   * @param value
+   */
+  private AffiliationCategory(String value) {
+    this.value = value
+  }
+
+  /**
+   * Returns to the enum item value
+   * @return
+   */
+  String getValue() {
+    return this.value
+  }
+
+  /**
+   * Returns a String representation of the enum item
+   * @return
+   */
+  @Override
+  String toString() {
+    return this.getValue()
+  }
+
+}

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/Customer.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/Customer.groovy
@@ -1,0 +1,13 @@
+package life.qbic.datamodel.dtos.business
+
+/**
+ * This class serves as a simple DTO for customer data
+ *
+ * A customer is a person to which QBiC has established
+ * any kind of business relationship.
+ *
+ * @author Sven Fillinger
+ * @since 1.11.0
+ */
+final class Customer {
+}

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/Customer.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/Customer.groovy
@@ -1,5 +1,11 @@
 package life.qbic.datamodel.dtos.business
 
+import org.apache.tools.ant.taskdefs.condition.Not
+
+import javax.validation.constraints.Email
+import javax.validation.constraints.NotEmpty
+import javax.validation.constraints.NotNull
+
 /**
  * This class serves as a simple DTO for customer data
  *
@@ -10,4 +16,49 @@ package life.qbic.datamodel.dtos.business
  * @since 1.11.0
  */
 final class Customer {
+
+  /**
+   * The customer's first name
+   */
+  final String firstName
+
+  /**
+   * The customer's last name
+   */
+  final String lastName
+
+  /**
+   * The customer's title
+   */
+  final String title
+
+  /**
+   * The customer's email address
+   */
+  final String eMailAddress
+
+  /**
+   * Associated affiliations
+   */
+  final List<Affiliation> affiliations
+
+  Customer(String firstName,
+           String lastName,
+           String title,
+           String eMailAddress,
+           List<Affiliation> affiliations) {
+    this.firstName = Objects.requireNonNull(firstName)
+    this.lastName = Objects.requireNonNull(lastName)
+    this.title = Objects.requireNonNull(title)
+    this.eMailAddress = Objects.requireNonNull(eMailAddress)
+    this.affiliations = new ArrayList<>()
+    copyAffiliations(affiliations)
+  }
+
+  private copyAffiliations(List<Affiliation> affiliations) {
+    for (Affiliation affiliation : affiliations) {
+      this.affiliations.add(affiliation)
+    }
+  }
+
 }

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/AffiliationSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/AffiliationSpec.groovy
@@ -17,7 +17,7 @@ class AffiliationSpec extends Specification{
             "Auf der Morgenstelle 10",
             "72076",
             "Tübingen").
-            country("Germany").build()
+           .build()
 
     then:
     assert testAffiliation.getOrganisation().equals("Universität Tübingen")

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/AffiliationSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/AffiliationSpec.groovy
@@ -16,7 +16,7 @@ class AffiliationSpec extends Specification{
         new Affiliation.Builder("Universität Tübingen",
             "Auf der Morgenstelle 10",
             "72076",
-            "Tübingen").
+            "Tübingen")
            .build()
 
     then:

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/AffiliationSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/AffiliationSpec.groovy
@@ -1,0 +1,28 @@
+package life.qbic.datamodel.dtos.business
+
+import spock.lang.Specification
+
+/**
+ * Simple test class to assert the correct behaviour of the Affiliation Builder.
+ *
+ * @author Sven Fillinger
+ * @since 1.11.0
+ */
+class AffiliationSpec extends Specification{
+
+  def "Fluent API shall create an affiliation object"() {
+    when:
+    Affiliation testAffiliation =
+        new Affiliation.Builder("Universität Tübingen",
+            "Auf der Morgenstelle 10",
+            "72076",
+            "Tübingen").
+            country("Germany").build()
+
+    then:
+    assert testAffiliation.getOrganisation().equals("Universität Tübingen")
+    assert testAffiliation.getCategory().equals(AffiliationCategory.EXTERNAL)
+    assert testAffiliation.getCountry().equals("Germany")
+  }
+
+}

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/CustomerSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/CustomerSpec.groovy
@@ -1,0 +1,21 @@
+package life.qbic.datamodel.dtos.business
+
+import spock.lang.Specification
+
+/**
+ * Simple tests for the customer dto class
+ *
+ * @author Sven Fillinger
+ * @since 1.11.0
+ */
+class CustomerSpec extends Specification{
+
+  def "wrong email shall raisa a validation exception"() {
+    when:
+    def customer = new Customer(null,"","","test",[])
+
+    then:
+    thrown(NullPointerException)
+  }
+
+}

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/CustomerSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/CustomerSpec.groovy
@@ -10,7 +10,7 @@ import spock.lang.Specification
  */
 class CustomerSpec extends Specification{
 
-  def "wrong email shall raisa a validation exception"() {
+  def "wrong email shall raise a validation exception"() {
     when:
     def customer = new Customer(null,"","","test",[])
 


### PR DESCRIPTION
This PR introduces two new DTOs: `Customer` and `Affiliation`, which can be used in any business related context.