### PR TITLE
Remove empty example package

### DIFF
--- a/src/main/groovy/life/qbic/example/Example.groovy
+++ b/src/main/groovy/life/qbic/example/Example.groovy
@@ -1,5 +1,0 @@
-package life.qbic.example
-
-class Example {
-
-}


### PR DESCRIPTION
This PR removes an empty Example class that was contained in an example package. The package was initially committed due to a template branch merge.