### PR TITLE
Add affiliation attribute to offer

### DIFF
--- a/src/main/groovy/life/qbic/datamodel/dtos/business/Offer.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/Offer.groovy
@@ -49,6 +49,10 @@ class Offer {
      * The identifier for the offer which makes it distinguishable from other offers
      */
     final OfferId identifier
+    /**
+     * The affiliation of the customer selected for this offer
+     */
+    final Affiliation selectedCustomerAffiliation
 
     static class Builder {
 
@@ -61,8 +65,9 @@ class Offer {
         List<ProductItem> items
         double totalPrice
         OfferId identifier
+        Affiliation selectedCustomerAffiliation
 
-        Builder(Date modificationDate, Date expirationDate, Customer customer, Person projectManager, String projectDescription, String projectTitle, List<ProductItem> items, double totalPrice, OfferId identifier) {
+        Builder(Date modificationDate, Date expirationDate, Customer customer, Person projectManager, String projectDescription, String projectTitle, List<ProductItem> items, double totalPrice, OfferId identifier, Affiliation selectedCustomerAffiliation) {
             this.modificationDate = modificationDate
             this.expirationDate = expirationDate
             this.customer = customer
@@ -72,6 +77,7 @@ class Offer {
             this.items = new ArrayList<ProductItem>(Collections.unmodifiableList(items))
             this.totalPrice = totalPrice
             this.identifier = identifier
+            this.selectedCustomerAffiliation = selectedCustomerAffiliation
         }
         //ToDo Determine if any properties should be able to be modified later or can't be set to Null
         Builder identifier(OfferId identifier) {
@@ -94,6 +100,7 @@ class Offer {
         this.items = builder.items
         this.totalPrice = builder.totalPrice
         this.identifier = builder.identifier
+        this.selectedCustomerAffiliation = builder.selectedCustomerAffiliation
     }
 
     /**

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/OfferSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/OfferSpec.groovy
@@ -18,6 +18,11 @@ class OfferSpec extends Specification {
         }
         Double price = 1000
         OfferId offerId = new OfferId("ab", "cd", 1)
+        Affiliation selectedAffiliation = new Affiliation.Builder("Universität Tübingen",
+                                        "Auf der Morgenstelle 10",
+                                        "72076",
+                                        "Tübingen")
+                                        .build()
 
         when:
         Offer testOffer =
@@ -29,7 +34,8 @@ class OfferSpec extends Specification {
                         "Archer",
                         [],
                         price,
-                        offerId)
+                        offerId,
+                        selectedAffiliation)
                         .build()
 
         then:
@@ -42,6 +48,7 @@ class OfferSpec extends Specification {
         testOffer.getItems() == []
         testOffer.getTotalPrice() == price
         testOffer.getIdentifier() == offerId
+        testOffer.getSelectedCustomerAffiliation() == selectedAffiliation
     }
 
 }


### PR DESCRIPTION
**Purpose of this PR**
Currently, it is not possible to calculate the offer price with the information provided in the Offer DTO since we do not have a field where we decide on a fixed affiliation for the customer. We only have a list of affiliations and thus cannot decide on the affiliation category to determine the overheads for the customer.

**Changes**
 I would suggest adding a field `selectedCustomerAffiliation` in the offer DTO since the affiliation of the customer is only fixed in the context of an offer.