### PR TITLE
Refactor/cost estimate and product item

### DIFF
--- a/src/main/groovy/life/qbic/datamodel/accounting/CostEstimate.groovy
+++ b/src/main/groovy/life/qbic/datamodel/accounting/CostEstimate.groovy
@@ -1,7 +1,8 @@
 package life.qbic.datamodel.accounting
 
+import life.qbic.datamodel.dtos.business.Affiliation
 import life.qbic.datamodel.dtos.business.CostEstimateId
-import life.qbic.datamodel.dtos.general.Person
+import life.qbic.datamodel.dtos.business.Customer
 
 /**
  * A cost estimate for a project
@@ -22,9 +23,19 @@ class CostEstimate {
     final Date creationDate
 
     /**
+     * The date on which the cost estimate expires
+     */
+    final Date expirationDate
+
+    /**
      * The customer for which the estimate is created
      */
-    final Person customer
+    final Customer customer
+
+    /**
+     * The QBiC project manager who was assigned to the project
+     */
+    final ProjectManager projectManager
 
     /**
      * The title of the project
@@ -51,14 +62,21 @@ class CostEstimate {
      */
     final CostEstimateId identifier
 
-    CostEstimate(Date creationDate, Person customer, String projectTitle, String projectDescription, List<ProductItem> items, double totalPrice, CostEstimateId identifier) {
+    /**
+     * An identifier which makes the CostEstimate distinguishable from other CostEstimates
+     */
+    final Affiliation selectedCustomerAffiliation
+
+    CostEstimate(Date creationDate, Customer customer, ProjectManager projectManager, String projectTitle, String projectDescription, List<ProductItem> items, double totalPrice, CostEstimateId identifier, Affiliation selectedCustomerAffiliation) {
         this.creationDate = creationDate
         this.customer = customer
+        this.projectManager = projectManager
         this.projectTitle = projectTitle
         this.projectDescription = projectDescription
         this.items = items
         this.totalPrice = totalPrice
         this.identifier = identifier
+        this.selectedCustomerAffiliation = selectedCustomerAffiliation
     }
 
     /**

--- a/src/main/groovy/life/qbic/datamodel/accounting/CostEstimate.groovy
+++ b/src/main/groovy/life/qbic/datamodel/accounting/CostEstimate.groovy
@@ -3,7 +3,7 @@ package life.qbic.datamodel.accounting
 import life.qbic.datamodel.dtos.business.Affiliation
 import life.qbic.datamodel.dtos.business.CostEstimateId
 import life.qbic.datamodel.dtos.business.Customer
-import life.qbic.datamodel.dtos.general.Person
+import life.qbic.datamodel.dtos.business.ProjectManager
 
 /**
  * A cost estimate for a project
@@ -36,7 +36,7 @@ class CostEstimate {
     /**
      * The QBiC project manager who was assigned to the project
      */
-    final Person projectManager
+    final ProjectManager projectManager
 
     /**
      * The title of the project
@@ -73,7 +73,7 @@ class CostEstimate {
         Date modificationDate
         Date expirationDate
         Customer customer
-        Person projectManager
+        ProjectManager projectManager
         String projectTitle
         String projectDescription
         List<ProductItem> items
@@ -81,7 +81,7 @@ class CostEstimate {
         CostEstimateId identifier
         Affiliation selectedCustomerAffiliation
 
-        Builder(Date modificationDate, Date expirationDate, Customer customer, Person projectManager, String projectDescription, String projectTitle, List<ProductItem> items, double totalPrice, CostEstimateId identifier, Affiliation selectedCustomerAffiliation) {
+        Builder(Date modificationDate, Date expirationDate, Customer customer, ProjectManager projectManager, String projectDescription, String projectTitle, List<ProductItem> items, double totalPrice, CostEstimateId identifier, Affiliation selectedCustomerAffiliation) {
             this.modificationDate = modificationDate
             this.expirationDate = expirationDate
             this.customer = customer

--- a/src/main/groovy/life/qbic/datamodel/accounting/CostEstimate.groovy
+++ b/src/main/groovy/life/qbic/datamodel/accounting/CostEstimate.groovy
@@ -3,6 +3,7 @@ package life.qbic.datamodel.accounting
 import life.qbic.datamodel.dtos.business.Affiliation
 import life.qbic.datamodel.dtos.business.CostEstimateId
 import life.qbic.datamodel.dtos.business.Customer
+import life.qbic.datamodel.dtos.general.Person
 
 /**
  * A cost estimate for a project
@@ -20,7 +21,7 @@ class CostEstimate {
     /**
      * The date on which the cost estimate was created
      */
-    final Date creationDate
+    final Date modificationDate
 
     /**
      * The date on which the cost estimate expires
@@ -35,7 +36,7 @@ class CostEstimate {
     /**
      * The QBiC project manager who was assigned to the project
      */
-    final ProjectManager projectManager
+    final Person projectManager
 
     /**
      * The title of the project
@@ -67,16 +68,53 @@ class CostEstimate {
      */
     final Affiliation selectedCustomerAffiliation
 
-    CostEstimate(Date creationDate, Customer customer, ProjectManager projectManager, String projectTitle, String projectDescription, List<ProductItem> items, double totalPrice, CostEstimateId identifier, Affiliation selectedCustomerAffiliation) {
-        this.creationDate = creationDate
-        this.customer = customer
-        this.projectManager = projectManager
-        this.projectTitle = projectTitle
-        this.projectDescription = projectDescription
-        this.items = items
-        this.totalPrice = totalPrice
-        this.identifier = identifier
-        this.selectedCustomerAffiliation = selectedCustomerAffiliation
+    static class Builder {
+
+        Date modificationDate
+        Date expirationDate
+        Customer customer
+        Person projectManager
+        String projectTitle
+        String projectDescription
+        List<ProductItem> items
+        double totalPrice
+        CostEstimateId identifier
+        Affiliation selectedCustomerAffiliation
+
+        Builder(Date modificationDate, Date expirationDate, Customer customer, Person projectManager, String projectDescription, String projectTitle, List<ProductItem> items, double totalPrice, CostEstimateId identifier, Affiliation selectedCustomerAffiliation) {
+            this.modificationDate = modificationDate
+            this.expirationDate = expirationDate
+            this.customer = customer
+            this.projectManager = projectManager
+            this.projectDescription = projectDescription
+            this.projectTitle = projectTitle
+            this.items = new ArrayList<ProductItem>(Collections.unmodifiableList(items))
+            this.totalPrice = totalPrice
+            this.identifier = identifier
+            this.selectedCustomerAffiliation = selectedCustomerAffiliation
+        }
+        //ToDo Determine if any properties should be able to be modified later or can't be set to Null
+        Builder identifier(CostEstimateId identifier) {
+            this.identifier = identifier
+            return this
+        }
+
+        CostEstimate build() {
+            return new CostEstimate(this)
+        }
+    }
+
+    private CostEstimate(Builder builder) {
+        this.modificationDate = builder.modificationDate
+        this.expirationDate = builder.expirationDate
+        this.customer = builder.customer
+        this.projectManager = builder.projectManager
+        this.projectDescription = builder.projectDescription
+        this.projectTitle = builder.projectTitle
+        this.items = builder.items
+        this.totalPrice = builder.totalPrice
+        this.identifier = builder.identifier
+        this.selectedCustomerAffiliation = builder.selectedCustomerAffiliation
     }
 
     /**

--- a/src/main/groovy/life/qbic/datamodel/accounting/Offer.groovy
+++ b/src/main/groovy/life/qbic/datamodel/accounting/Offer.groovy
@@ -1,7 +1,8 @@
 package life.qbic.datamodel.accounting
 
+import life.qbic.datamodel.dtos.business.Customer
 import life.qbic.datamodel.dtos.business.OfferId
-import life.qbic.datamodel.dtos.general.Person
+import life.qbic.datamodel.dtos.business.ProjectManager
 
 /**
  * An offer for a project
@@ -28,12 +29,12 @@ class Offer {
     /**
      * The customer for which this offer was created
      */
-    final Person customer
+    final Customer customer
 
     /**
      * The QBiC project manager who was assigned to the project
      */
-    final Person projectManager
+    final ProjectManager projectManager
 
     /**
      * The title of the project
@@ -60,7 +61,7 @@ class Offer {
      */
     final OfferId identifier
 
-    Offer(Date modificationDate, Date expirationDate, Person customer, Person projectManager, String projectTitle, String projectDescription, List<ProductItem> items, double totalPrice, OfferId identifier) {
+    Offer(Date modificationDate, Date expirationDate, Customer customer, ProjectManager projectManager, String projectTitle, String projectDescription, List<ProductItem> items, double totalPrice, OfferId identifier) {
         this.modificationDate = modificationDate
         this.expirationDate = expirationDate
         this.customer = customer

--- a/src/main/groovy/life/qbic/datamodel/accounting/ProductItem.groovy
+++ b/src/main/groovy/life/qbic/datamodel/accounting/ProductItem.groovy
@@ -47,12 +47,5 @@ class ProductItem {
         this.product = product
     }
 
-    /**
-     * Calculates the cost of the item based on its quantity and the price and unit defined in the product
-     * @return
-     */
-    double computeTotalCosts(){
-        return product.unitPrice * quantity
-    }
 }
 

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/Customer.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/Customer.groovy
@@ -15,14 +15,12 @@ import life.qbic.datamodel.dtos.general.Person
 @EqualsAndHashCode
 final class Customer extends Person{
 
-  private static final String TYPE = "customer"
-
   Customer(String firstName,
            String lastName,
            AcademicTitle title,
            String eMailAddress,
            List<Affiliation> affiliations) {
-    super(TYPE,firstName,lastName,title,eMailAddress,affiliations)
+    super(firstName,lastName,title,eMailAddress,affiliations)
   }
 
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/ProjectManager.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/ProjectManager.groovy
@@ -1,0 +1,22 @@
+package life.qbic.datamodel.dtos.business
+
+import life.qbic.datamodel.dtos.general.Person
+
+/**
+ * This class serves as a simple DTO representing a ProjectManager
+ *
+ * A projectManager is a person which is responsible for managing
+ * projects in a business relationship
+ *
+ * @since 1.12.0
+ */
+class ProjectManager extends Person {
+
+    ProjectManager(String firstName,
+             String lastName,
+             AcademicTitle title,
+             String eMailAddress,
+             List<Affiliation> affiliations) {
+        super(firstName,lastName,title,eMailAddress,affiliations)
+    }
+}

--- a/src/main/groovy/life/qbic/datamodel/dtos/general/Person.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/general/Person.groovy
@@ -17,11 +17,6 @@ import life.qbic.datamodel.dtos.business.Affiliation
 abstract class Person {
 
   /**
-   * The type of person e.g. customer, project manager
-   */
-  final String personType
-
-  /**
    * The person's first name
    */
   final String firstName
@@ -46,13 +41,11 @@ abstract class Person {
    */
   final List<Affiliation> affiliations
 
-  Person(String personType,
-         String firstName,
+  Person(String firstName,
          String lastName,
          AcademicTitle title,
          String eMailAddress,
          List<Affiliation> affiliations) {
-    this.personType = Objects.requireNonNull(personType)
     this.firstName = Objects.requireNonNull(firstName)
     this.lastName = Objects.requireNonNull(lastName)
     this.title = Objects.requireNonNull(title)

--- a/src/main/groovy/life/qbic/datamodel/people/Person.groovy
+++ b/src/main/groovy/life/qbic/datamodel/people/Person.groovy
@@ -1,5 +1,6 @@
 package life.qbic.datamodel.people;
 
+@Deprecated
 class Person {
 
   private String firstName

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/CostEstimateSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/CostEstimateSpec.groovy
@@ -1,7 +1,6 @@
 package life.qbic.datamodel.dtos.business
 
 import life.qbic.datamodel.accounting.CostEstimate
-import life.qbic.datamodel.dtos.general.Person
 import spock.lang.Specification
 
 /**
@@ -18,7 +17,7 @@ class CostEstimateSpec extends Specification{
             Date date = new Date(1000, 10, 10)
             AcademicTitleFactory academicTitleFactory = new AcademicTitleFactory()
             Customer customer = new Customer("", "", academicTitleFactory.getForString("None"), "", [])
-            Person projectManager = new Person("Project Manager", "Malory", "Archer", academicTitleFactory.getForString("None"), "", []) {
+            ProjectManager projectManager = new ProjectManager("Malory", "Archer", academicTitleFactory.getForString("None"), "", []) {
             }
             Double price = 1000
             CostEstimateId costEstimateId= new CostEstimateId("ab", "cd", 1)

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/CostEstimateSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/CostEstimateSpec.groovy
@@ -1,0 +1,57 @@
+package life.qbic.datamodel.dtos.business
+
+import life.qbic.datamodel.accounting.CostEstimate
+import life.qbic.datamodel.dtos.general.Person
+import spock.lang.Specification
+
+/**
+ * Simple test class to assert the correct behaviour of the CostEstimate Builder.
+ *
+ * @since 1.12.0
+ */
+
+class CostEstimateSpec extends Specification{
+
+        def "Fluent API shall create a CustomerEstimate object"() {
+
+            given:
+            Date date = new Date(1000, 10, 10)
+            AcademicTitleFactory academicTitleFactory = new AcademicTitleFactory()
+            Customer customer = new Customer("", "", academicTitleFactory.getForString("None"), "", [])
+            Person projectManager = new Person("Project Manager", "Malory", "Archer", academicTitleFactory.getForString("None"), "", []) {
+            }
+            Double price = 1000
+            CostEstimateId costEstimateId= new CostEstimateId("ab", "cd", 1)
+            Affiliation selectedAffiliation = new Affiliation.Builder("Universität Tübingen",
+                    "Auf der Morgenstelle 10",
+                    "72076",
+                    "Tübingen")
+                    .build()
+
+            when:
+            CostEstimate costEstimate =
+                    new CostEstimate.Builder(date,
+                            date,
+                            customer,
+                            projectManager,
+                            "Cartoon Series",
+                            "Archer",
+                            [],
+                            price,
+                            costEstimateId,
+                            selectedAffiliation)
+                            .build()
+
+            then:
+            costEstimate.getModificationDate() == date
+            costEstimate.getExpirationDate() == date
+            costEstimate.getCustomer() == customer
+            costEstimate.getProjectManager() == projectManager
+            costEstimate.getProjectDescription() == "Cartoon Series"
+            costEstimate.getProjectTitle() == "Archer"
+            costEstimate.getItems() == []
+            costEstimate.getTotalPrice() == price
+            costEstimate.getIdentifier() == costEstimateId
+            costEstimate.getSelectedCustomerAffiliation() == selectedAffiliation
+        }
+}

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/CustomerSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/CustomerSpec.groovy
@@ -36,10 +36,10 @@ class CustomerSpec extends Specification{
 
   def "missing affiliation list shall cause the customer to contain an empty list"() {
     when:
-    def customer = new Customer("", "", AcademicTitle.NONE, "a.b@c.de", null)
+    def projectManager = new ProjectManager("", "", AcademicTitle.NONE, "a.b@c.de", null)
     then:
-    customer.affiliations != null
-    customer.affiliations.isEmpty()
+    projectManager.affiliations != null
+    projectManager.affiliations.isEmpty()
   }
 
 }

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/CustomerSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/CustomerSpec.groovy
@@ -36,10 +36,10 @@ class CustomerSpec extends Specification{
 
   def "missing affiliation list shall cause the customer to contain an empty list"() {
     when:
-    def projectManager = new ProjectManager("", "", AcademicTitle.NONE, "a.b@c.de", null)
+    def customer = new Customer( "", "", AcademicTitle.NONE, "a.b@c.de", null)
     then:
-    projectManager.affiliations != null
-    projectManager.affiliations.isEmpty()
+    customer.affiliations != null
+    customer.affiliations.isEmpty()
   }
 
 }

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/OfferSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/OfferSpec.groovy
@@ -1,6 +1,6 @@
 package life.qbic.datamodel.dtos.business
 
-import life.qbic.datamodel.dtos.general.Person
+
 import spock.lang.Specification
 
 /**
@@ -17,8 +17,7 @@ class OfferSpec extends Specification {
         Date date = new Date(1000, 10, 10)
         AcademicTitleFactory academicTitleFactory = new AcademicTitleFactory()
         Customer customer = new Customer("", "", academicTitleFactory.getForString("None"), "", [])
-        Person projectManager = new Person("Project Manager", "Malory", "Archer", academicTitleFactory.getForString("None"), "", []) {
-        }
+        ProjectManager projectManager = new ProjectManager("Malory", "Archer", academicTitleFactory.getForString("None"), "", [])
         Double price = 1000
         OfferId offerId = new OfferId("ab", "cd", 1)
         Affiliation selectedAffiliation = new Affiliation.Builder("Universität Tübingen",

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/OfferSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/OfferSpec.groovy
@@ -1,12 +1,15 @@
 package life.qbic.datamodel.dtos.business
 
-import life.qbic.datamodel.accounting.Product
-import life.qbic.datamodel.accounting.ProductItem
 import life.qbic.datamodel.dtos.general.Person
 import spock.lang.Specification
 
-class OfferSpec extends Specification {
+/**
+ * Simple test class to assert the correct behaviour of the Offer Builder.
+ *
+ * @since 1.12.0
+ */
 
+class OfferSpec extends Specification {
 
     def "Fluent API shall create an Offer object"() {
 

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/ProductItemSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/ProductItemSpec.groovy
@@ -1,0 +1,39 @@
+package life.qbic.datamodel.dtos.business
+
+import life.qbic.datamodel.accounting.Product
+import life.qbic.datamodel.accounting.ProductCategory
+import life.qbic.datamodel.accounting.ProductItem
+import spock.lang.Specification
+
+/**
+ * Simple tests for the ProductItem dto class
+ *
+ * @since 1.12.0
+ */
+class ProductItemSpec extends Specification{
+
+    Product product = new Product(ProductCategory.PRIMARY_BIOINFO, null, "", "", 0, "", false)
+
+    def "ProductItem shall store and provide the given properties: name, description and product"() {
+        when:
+        def productItem = new ProductItem("Pandoras Box", "Don't open it!", product)
+
+        then:
+        productItem.NAME == "Pandoras Box"
+        productItem.DESCRIPTION == "Don't open it!"
+        productItem.product == product
+    }
+
+    def "ProductItem shall store and provide the given properties: quantity, name, description and product"() {
+        when:
+        def productItem = new ProductItem(1, "Pandoras Box", "Don't open it!", product)
+
+        then:
+        productItem.quantity == 1
+        productItem.NAME == "Pandoras Box"
+        productItem.DESCRIPTION == "Don't open it!"
+        productItem.product == product
+    }
+
+
+}

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/ProjectManagerSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/ProjectManagerSpec.groovy
@@ -1,0 +1,43 @@
+package life.qbic.datamodel.dtos.business
+
+import spock.lang.Specification
+
+/**
+ * Simple tests for the projectManager dto class
+ *
+ * @since 1.12.0
+ */
+class ProjectManagerSpec extends Specification {
+
+        def "missing first name shall raise a NullPointerException"() {
+            when:
+            def projectManager = new ProjectManager(null, "", AcademicTitle.NONE, "a.b@c.de", [])
+
+            then:
+            thrown(NullPointerException)
+        }
+
+        def "missing last name shall raise a NullPointerException"() {
+            when:
+            def projectManager = new ProjectManager("", null, AcademicTitle.NONE, "a.b@c.de", [])
+
+            then:
+            thrown(NullPointerException)
+        }
+
+        def "missing email name shall raise a NullPointerException"() {
+            when:
+            def projectManager = new ProjectManager("", "", AcademicTitle.NONE, null, [])
+
+            then:
+            thrown(NullPointerException)
+        }
+
+        def "missing affiliation list shall cause the projectManager to contain an empty list"() {
+            when:
+            def projectManager = new ProjectManager("", "", AcademicTitle.NONE, "a.b@c.de", null)
+            then:
+            projectManager.affiliations != null
+            projectManager.affiliations.isEmpty()
+        }
+    }


### PR DESCRIPTION
**Purpose of this PR**
This PR refactors the `CostEstimate` Class to the same builder pattern as the `Offer` Class. 
Additionally it adds the previously missing fields `ExpirationDate` and `ProjectManager` to the `CostEstimate `class 
and removes the ` computeTotalCost `method  from the `ProductItem` class making `ProductItem` a proper dto.
Finally it introduces simple tests for the introduced and changed classes. 

**Misc**
This PR also deprecates the `Person` class to mark it for future removal, since i was unsure if that tag in itself would be worth a seperate PR. 