### PR TITLE
Provide more unit enums

### DIFF
--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProductUnit.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProductUnit.groovy
@@ -7,7 +7,9 @@ package life.qbic.datamodel.dtos.business.services
  */
 enum ProductUnit {
 
-  PER_GIGABYTE("per 1 GB")
+  PER_GIGABYTE("1 GB"),
+  PER_SAMPLE("Sample"),
+  PER_DATASET("Dataset")
 
   /**
    Holds the String value of the enum


### PR DESCRIPTION
This PR adds two more unit enums for the service products.

The new enums are "Sample" and "Dataset".