### PR TITLE
Make quantity modifiable

### DIFF
--- a/src/main/groovy/life/qbic/datamodel/accounting/ProductItem.groovy
+++ b/src/main/groovy/life/qbic/datamodel/accounting/ProductItem.groovy
@@ -18,7 +18,7 @@ class ProductItem {
     /**
      * Describes the amount of a given item
      */
-    final double quantity
+    double quantity
 
     /**
      * Describes the which product type of the current item


### PR DESCRIPTION
The quantity of a ProductItem is something that needs to change by the request of the user. Therefore, the attribute should be no longer final