### PR TITLE
Change '1 GB'  to 'Gigabyte'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 * Add bnd.bnd file to enable OSGI bundling
 
 **Fixed**
+* Change ProductUnit.PER_GIGABYTE String representation to `Gigabyte`
 
 **Dependencies**
 

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProductUnit.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProductUnit.groovy
@@ -7,7 +7,7 @@ package life.qbic.datamodel.dtos.business.services
  */
 enum ProductUnit {
 
-  PER_GIGABYTE("1 GB"),
+  PER_GIGABYTE("Gigabyte"),
   PER_SAMPLE("Sample"),
   PER_DATASET("Dataset")
 


### PR DESCRIPTION
Many thanks for contributing to this project!

**PR Checklist**
Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

- [x] This comment contains a description of changes (with reason)
- [ ] Referenced issue is linked
- [x] `CHANGELOG.rst` is updated

**Description of changes**
The string value of the ProductUnit.PER_GIGABYTE enum was changed from `GB` to `Gigabyte` to avoid confusion with Gigabases or similar.
