### PR TITLE
add currency for products

### DIFF
--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/Product.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/Product.groovy
@@ -29,6 +29,11 @@ abstract class Product {
   final double unitPrice
 
   /**
+   * The currency of the price
+   */
+  final Currency currency
+
+  /**
    * The unit of the product.
    */
   final ProductUnit unit
@@ -48,6 +53,8 @@ abstract class Product {
     this.description = Objects.requireNonNull(description, "Description must not be null")
     this.unitPrice = Objects.requireNonNull(unitPrice, "Unit price must not be null")
     this.unit = Objects.requireNonNull(unit, "Unit must not be null")
+    //currency is on default in euro
+    this.currency = Currency.getInstance(Locale.GERMANY)
   }
 
 }

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/ProductItemSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/ProductItemSpec.groovy
@@ -32,5 +32,14 @@ class ProductItemSpec extends Specification {
         product == product2
     }
 
+    def "Product currency is euro"(){
+        when:
+        Product product = new Sequencing("RNA Sequencing", "This package manages the pricing for all RNA sequencings", 1.0, ProductUnit.PER_SAMPLE)
+
+        then:
+        product.currency.symbol == "EUR"
+        product.currency.displayName == "Euro"
+    }
+
 
 }

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/ProductItemSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/ProductItemSpec.groovy
@@ -37,7 +37,7 @@ class ProductItemSpec extends Specification {
         Product product = new Sequencing("RNA Sequencing", "This package manages the pricing for all RNA sequencings", 1.0, ProductUnit.PER_SAMPLE)
 
         then:
-        product.currency.symbol == "EUR"
+        product.currency.toString() == "EUR"
         product.currency.displayName == "Euro"
     }
 


### PR DESCRIPTION
**Purpose of change**
Products do not only have prices but also a currency for them

**Changes**
Products have now a currency attribute that is on default in Euro. Furthermore, a test for the currency is added to ensure that is value is in Euro.