### PR TITLE
Change offer id version to String

### DIFF
--- a/src/main/groovy/life/qbic/datamodel/dtos/business/OfferId.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/OfferId.groovy
@@ -15,7 +15,7 @@ class OfferId extends TomatoId{
     private static final String TYPE = "O"
 
 
-    OfferId(String projectConservedPart, String randomPart, int version) {
+    OfferId(String projectConservedPart, String randomPart, String version) {
         super(TYPE,projectConservedPart,randomPart,version)
     }
 

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/TomatoId.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/TomatoId.groovy
@@ -23,9 +23,9 @@ abstract class TomatoId {
      */
     private String random
     /**
-     * Version of the identifier which is a number between 0 and 9
+     * Version of the identifier
      */
-    private int version
+    private String version
 
     /**
      * Creates an identifier object with the
@@ -35,7 +35,7 @@ abstract class TomatoId {
      * @param randomPart describes the random part of the identifier
      * @param version describes the version of the identifier
      */
-    TomatoId(String type, String projectConservedPart, String randomPart, int version){
+    TomatoId(String type, String projectConservedPart, String randomPart, String version){
         this.type = Objects.requireNonNull(type, "type must not be null")
         this.projectConserved = Objects.requireNonNull(projectConservedPart, "projectConservedPart must not be null")
         this.random = Objects.requireNonNull(randomPart, "randomPart must not be null")
@@ -74,7 +74,7 @@ abstract class TomatoId {
      * Returns the version of the identifier
      * @return
      */
-    int getVersion() {
+    String getVersion() {
         return version
     }
     /**

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/OfferSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/OfferSpec.groovy
@@ -29,7 +29,7 @@ class OfferSpec extends Specification {
         double vat = 0.19
         double overhead = 0.2
         double net = 900
-        OfferId offerId = new OfferId("ab", "cd", 1)
+        OfferId offerId = new OfferId("ab", "cd", "1")
         ProductItem item = new ProductItem(2,new Sequencing("DNA Sequencing","This is a sequencing package",1.50, ProductUnit.PER_SAMPLE))
 
         when:
@@ -57,7 +57,7 @@ class OfferSpec extends Specification {
     def "Missing optional Field definitions shall haven null values in an Offer object"() {
 
         given:
-        OfferId offerId = new OfferId("ab", "cd", 1)
+        OfferId offerId = new OfferId("ab", "cd", "1")
 
         when:
         Offer testOffer =


### PR DESCRIPTION
The version can be everything, not only a number.

To not get locked in here, we convert the version property to a String instead of an Integer.