### PR TITLE
Include PhD in Academic Title DTO

### DIFF
--- a/src/main/groovy/life/qbic/datamodel/dtos/business/AcademicTitle.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/AcademicTitle.groovy
@@ -12,7 +12,8 @@ enum AcademicTitle {
 
     PROFESSOR("Prof. Dr."),
     DOCTOR("Dr."),
-    NONE("None")
+    NONE("None"),
+    PHD("PhD")
 
     /**
      Holds the String value of the enum

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/AcademicTitleFactorySpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/AcademicTitleFactorySpec.groovy
@@ -17,6 +17,7 @@ class AcademicTitleFactorySpec extends Specification {
         factory.getForString("None") == AcademicTitle.NONE
         factory.getForString("Dr.") == AcademicTitle.DOCTOR
         factory.getForString("Prof. Dr.") == AcademicTitle.PROFESSOR
+        factory.getForString("PhD") == AcademicTitle.PHD
     }
 
     def "GetForString works for correct strings regardless of leading and tailing whitespace"() {
@@ -27,14 +28,17 @@ class AcademicTitleFactorySpec extends Specification {
         factory.getForString(" None") == AcademicTitle.NONE
         factory.getForString(" Dr.") == AcademicTitle.DOCTOR
         factory.getForString(" Prof. Dr.") == AcademicTitle.PROFESSOR
+        factory.getForString(" Phd") == AcademicTitle.PHD
 
         factory.getForString("None ") == AcademicTitle.NONE
         factory.getForString("Dr. ") == AcademicTitle.DOCTOR
         factory.getForString("Prof. Dr. ") == AcademicTitle.PROFESSOR
+        factory.getForString("Phd ") == AcademicTitle.PHD
 
         factory.getForString(" None ") == AcademicTitle.NONE
         factory.getForString(" Dr. ") == AcademicTitle.DOCTOR
         factory.getForString(" Prof. Dr. ") == AcademicTitle.PROFESSOR
+        factory.getForString(" Phd ") == AcademicTitle.PHD
     }
 
     def "GetForString throws IllegalArgumentException for incorrect values"() {

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/AcademicTitleFactorySpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/AcademicTitleFactorySpec.groovy
@@ -28,17 +28,17 @@ class AcademicTitleFactorySpec extends Specification {
         factory.getForString(" None") == AcademicTitle.NONE
         factory.getForString(" Dr.") == AcademicTitle.DOCTOR
         factory.getForString(" Prof. Dr.") == AcademicTitle.PROFESSOR
-        factory.getForString(" Phd") == AcademicTitle.PHD
+        factory.getForString(" PhD") == AcademicTitle.PHD
 
         factory.getForString("None ") == AcademicTitle.NONE
         factory.getForString("Dr. ") == AcademicTitle.DOCTOR
         factory.getForString("Prof. Dr. ") == AcademicTitle.PROFESSOR
-        factory.getForString("Phd ") == AcademicTitle.PHD
+        factory.getForString("PhD ") == AcademicTitle.PHD
 
         factory.getForString(" None ") == AcademicTitle.NONE
         factory.getForString(" Dr. ") == AcademicTitle.DOCTOR
         factory.getForString(" Prof. Dr. ") == AcademicTitle.PROFESSOR
-        factory.getForString(" Phd ") == AcademicTitle.PHD
+        factory.getForString(" PhD ") == AcademicTitle.PHD
     }
 
     def "GetForString throws IllegalArgumentException for incorrect values"() {


### PR DESCRIPTION
**Description of changes**
This PR is necessary to address Issue [#269](https://github.com/qbicsoftware/offer-manager-2-portlet/issues/269) of the offer-manager-2-portlet. 
It adds PhD to the `Academic Title` DTO and adapts the testing accordingly.

**Additional context**
I also updated the database column with the new PhD Value 
