### PR TITLE
Add ProductId attribute to Product DTOs

### DIFF
--- a/src/main/groovy/life/qbic/datamodel/dtos/business/ProductId.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/ProductId.groovy
@@ -34,7 +34,7 @@ class ProductId {
 
     ProductId(String type, String version){
         this.type = Objects.requireNonNull(type, "type must not be null")
-        this.version= Objects.requireNonNull(type, "version must not be null")
+        this.version= Objects.requireNonNull(version, "version must not be null")
 
     }
 

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/ProductId.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/ProductId.groovy
@@ -1,0 +1,67 @@
+package life.qbic.datamodel.dtos.business
+
+import groovy.transform.CompileStatic
+
+/**
+ * A DTO describing Product Identifiers
+ *
+ * The ProductId should be used as a general class describing identifiers like the {@link OfferId} and the {@link CostEstimateId}.
+ * It consists of a fixed Part depending on the product category and an Integer based versioning
+ *
+ * @since: 1.13.0
+ *
+ */
+
+@CompileStatic
+class ProductId {
+
+    /**
+     * The type of the identifier is defined by the implementing identifier
+     */
+    final private String type
+
+    /**
+     * Version of the identifier
+     */
+    final private String version
+
+    /**
+     * Creates an identifier object with the
+     *
+     * @param type describing the type of the underlying identifier
+     * @param version describes the version of the identifier
+     */
+
+    ProductId(String type, String version){
+        this.type = Objects.requireNonNull(type, "type must not be null")
+        this.version= Objects.requireNonNull(type, "version must not be null")
+
+    }
+
+    /**
+     * Returns the version of the identifier
+     * @return
+     */
+    String getVersion() {
+        return version
+    }
+    /**
+     * Returns the type of the identifier
+     * @return
+     */
+    String getType() {
+        return type
+    }
+
+    /**
+     * Returns a String representation in the format:
+     *
+     *      [type]_[version]
+     *
+     * @return A String representation of the identifier
+     */
+    @Override
+    String toString() {
+        return type + "_" + version
+    }
+}

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/ProductId.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/ProductId.groovy
@@ -21,29 +21,29 @@ class ProductId {
     final private String type
 
     /**
-     * Version of the identifier
+     * Identifying number used in conjunction with the type
      */
-    final private String version
+    final private String identifier
 
     /**
      * Creates an identifier object with the
      *
      * @param type describing the type of the underlying identifier
-     * @param version describes the version of the identifier
+     * @param identifier describes the identifying running number
      */
 
-    ProductId(String type, String version){
+    ProductId(String type, String identifier){
         this.type = Objects.requireNonNull(type, "type must not be null")
-        this.version= Objects.requireNonNull(version, "version must not be null")
+        this.identifier= Objects.requireNonNull(identifier, "version must not be null")
 
     }
 
     /**
-     * Returns the version of the identifier
+     * Returns the identifying running number
      * @return
      */
-    String getVersion() {
-        return version
+    String getIdentifier() {
+        return identifier
     }
     /**
      * Returns the type of the identifier
@@ -62,6 +62,6 @@ class ProductId {
      */
     @Override
     String toString() {
-        return type + "_" + version
+        return type + "_" + identifier
     }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/AtomicProduct.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/AtomicProduct.groovy
@@ -1,6 +1,7 @@
 package life.qbic.datamodel.dtos.business.services
 
 import groovy.transform.EqualsAndHashCode
+import life.qbic.datamodel.dtos.business.ProductId
 
 /**
  * Describes a product type that can only have positive natural unit multipliers (N={0,1...,inf+})
@@ -21,8 +22,9 @@ class AtomicProduct extends Product {
    * @param description The description of what the product is about.
    * @param unitPrice The price in € per unit
    * @param unit The product unit
+   * @param productId The product identifier
    */
-  AtomicProduct(String name, String description, double unitPrice, ProductUnit unit) {
-    super(name, description, unitPrice, unit)
+  AtomicProduct(String name, String description, double unitPrice, ProductUnit unit, ProductId productId) {
+    super(name, description, unitPrice, unit, productId)
   }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/DataStorage.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/DataStorage.groovy
@@ -21,7 +21,10 @@ class DataStorage extends PartialProduct {
    * @param unit The product unit
    * @param productId The product identifier
    */
-  DataStorage(String name, String description, double unitPrice, ProductUnit unit, ProductId productId) {
-    super(name, description, unitPrice, unit, productId)
+
+  private static final String TYPE = "DS"
+
+  DataStorage(String name, String description, double unitPrice, ProductUnit unit, String identifier) {
+    super(name, description, unitPrice, unit, new ProductId(TYPE, identifier))
   }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/DataStorage.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/DataStorage.groovy
@@ -1,6 +1,7 @@
 package life.qbic.datamodel.dtos.business.services
 
 import groovy.transform.EqualsAndHashCode
+import life.qbic.datamodel.dtos.business.ProductId
 
 /**
  * Describes a product for data storage services.
@@ -18,8 +19,9 @@ class DataStorage extends PartialProduct {
    * @param description The description of what the product is about.
    * @param unitPrice The price in € per unit
    * @param unit The product unit
+   * @param productId The product identifier
    */
-  DataStorage(String name, String description, double unitPrice, ProductUnit unit) {
-    super(name, description, unitPrice, unit)
+  DataStorage(String name, String description, double unitPrice, ProductUnit unit, ProductId productId) {
+    super(name, description, unitPrice, unit, productId)
   }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/PartialProduct.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/PartialProduct.groovy
@@ -1,6 +1,7 @@
 package life.qbic.datamodel.dtos.business.services
 
 import groovy.transform.EqualsAndHashCode
+import life.qbic.datamodel.dtos.business.ProductId
 
 /**
  * Describes a product type that can only have positive natural unit multipliers (N={0,1...,inf+})
@@ -22,8 +23,9 @@ class PartialProduct extends Product {
    * @param description The description of what the product is about.
    * @param unitPrice The price in € per unit
    * @param unit The product unit
+   * @param productId The product identifier
    */
-  PartialProduct(String name, String description, double unitPrice, ProductUnit unit) {
-    super(name, description, unitPrice, unit)
+  PartialProduct(String name, String description, double unitPrice, ProductUnit unit, ProductId productId) {
+    super(name, description, unitPrice, unit, productId)
   }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/PrimaryAnalysis.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/PrimaryAnalysis.groovy
@@ -1,6 +1,7 @@
 package life.qbic.datamodel.dtos.business.services
 
 import groovy.transform.EqualsAndHashCode
+import life.qbic.datamodel.dtos.business.ProductId
 
 /**
  * Describes a product for primary bioinformatic analysis services.
@@ -18,8 +19,9 @@ class PrimaryAnalysis extends AtomicProduct {
    * @param description The description of what the product is about.
    * @param unitPrice The price in € per unit
    * @param unit The product unit
+   * @param productId The product identifier
    */
-  PrimaryAnalysis(String name, String description, double unitPrice, ProductUnit unit) {
-    super(name, description, unitPrice, unit)
+  PrimaryAnalysis(String name, String description, double unitPrice, ProductUnit unit, ProductId productId) {
+    super(name, description, unitPrice, unit, productId)
   }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/PrimaryAnalysis.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/PrimaryAnalysis.groovy
@@ -21,7 +21,10 @@ class PrimaryAnalysis extends AtomicProduct {
    * @param unit The product unit
    * @param productId The product identifier
    */
-  PrimaryAnalysis(String name, String description, double unitPrice, ProductUnit unit, ProductId productId) {
-    super(name, description, unitPrice, unit, productId)
+
+  private static final String TYPE = "PB"
+
+  PrimaryAnalysis(String name, String description, double unitPrice, ProductUnit unit, String identifier) {
+    super(name, description, unitPrice, unit, new ProductId(TYPE, identifier))
   }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/Product.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/Product.groovy
@@ -1,6 +1,7 @@
 package life.qbic.datamodel.dtos.business.services
 
 import groovy.transform.EqualsAndHashCode
+import life.qbic.datamodel.dtos.business.ProductId
 
 /**
  * Holds information about a simple QBiC service product.
@@ -39,22 +40,30 @@ abstract class Product {
   final ProductUnit unit
 
   /**
+   * The Id of the product.
+   */
+  final ProductId productId
+
+  /**
    * Basic product constructor.
    *
-   * Checks that all passed arguments are not null.
+   * Checks that all passed arguments except productId are not null.
    *
    * @param name The name of the product.
    * @param description The description of what the product is about.
    * @param unitPrice The price in € per unit
    * @param unit The product unit
+   * @param productId The Id of the product
    */
-  Product(String name, String description, double unitPrice, ProductUnit unit) {
+  Product(String name, String description, double unitPrice, ProductUnit unit, ProductId productId) {
     this.productName = Objects.requireNonNull(name, "Name must not be null")
     this.description = Objects.requireNonNull(description, "Description must not be null")
     this.unitPrice = Objects.requireNonNull(unitPrice, "Unit price must not be null")
     this.unit = Objects.requireNonNull(unit, "Unit must not be null")
+    this.productId = Objects.requireNonNull(productId, "ProductId must not be null")
     //currency is on default in euro
     this.currency = Currency.getInstance(Locale.GERMANY)
+
   }
 
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProjectManagement.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProjectManagement.groovy
@@ -1,6 +1,7 @@
 package life.qbic.datamodel.dtos.business.services
 
 import groovy.transform.EqualsAndHashCode
+import life.qbic.datamodel.dtos.business.ProductId
 
 /**
  * Describes a product for project management services.
@@ -18,8 +19,9 @@ class ProjectManagement extends PartialProduct {
    * @param description The description of what the product is about.
    * @param unitPrice The price in € per unit
    * @param unit The product unit
+   * @param productId The product identifier
    */
-  ProjectManagement(String name, String description, double unitPrice, ProductUnit unit) {
-    super(name, description, unitPrice, unit)
+  ProjectManagement(String name, String description, double unitPrice, ProductUnit unit, ProductId productId) {
+    super(name, description, unitPrice, unit, productId)
   }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProjectManagement.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProjectManagement.groovy
@@ -21,7 +21,10 @@ class ProjectManagement extends PartialProduct {
    * @param unit The product unit
    * @param productId The product identifier
    */
-  ProjectManagement(String name, String description, double unitPrice, ProductUnit unit, ProductId productId) {
-    super(name, description, unitPrice, unit, productId)
+
+  private static final String TYPE = "PM"
+
+  ProjectManagement(String name, String description, double unitPrice, ProductUnit unit, String identifier) {
+    super(name, description, unitPrice, unit, new ProductId(TYPE, identifier))
   }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/SecondaryAnalysis.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/SecondaryAnalysis.groovy
@@ -1,6 +1,8 @@
 package life.qbic.datamodel.dtos.business.services
 
 import groovy.transform.EqualsAndHashCode
+import life.qbic.datamodel.dtos.business.ProductId
+
 
 /**
  * Describes a product for secondary bioinformatic analysis services.
@@ -18,8 +20,12 @@ class SecondaryAnalysis extends AtomicProduct {
    * @param description The description of what the product is about.
    * @param unitPrice The price in € per unit
    * @param unit The product unit
+   * @param productId The product identifier
    */
-  SecondaryAnalysis(String name, String description, double unitPrice, ProductUnit unit) {
-    super(name, description, unitPrice, unit)
+
+  SecondaryAnalysis(String name, String description, double unitPrice, ProductUnit unit, ProductId productId) {
+
+    super(name, description, unitPrice, unit, productId)
+
   }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/SecondaryAnalysis.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/SecondaryAnalysis.groovy
@@ -22,10 +22,11 @@ class SecondaryAnalysis extends AtomicProduct {
    * @param unit The product unit
    * @param productId The product identifier
    */
+  private static final String TYPE = "SB"
 
-  SecondaryAnalysis(String name, String description, double unitPrice, ProductUnit unit, ProductId productId) {
+  SecondaryAnalysis(String name, String description, double unitPrice, ProductUnit unit, String identifier) {
 
-    super(name, description, unitPrice, unit, productId)
+    super(name, description, unitPrice, unit, new ProductId(TYPE , identifier))
 
   }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/Sequencing.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/Sequencing.groovy
@@ -1,6 +1,7 @@
 package life.qbic.datamodel.dtos.business.services
 
 import groovy.transform.EqualsAndHashCode
+import life.qbic.datamodel.dtos.business.ProductId
 
 /**
  * Describes a product for sequencing services.
@@ -18,8 +19,9 @@ class Sequencing extends AtomicProduct {
    * @param description The description of what the product is about.
    * @param unitPrice The price in € per unit
    * @param unit The product unit
+   * @param productId The product identifier
    */
-  Sequencing(String name, String description, double unitPrice, ProductUnit unit) {
-    super(name, description, unitPrice, unit)
+  Sequencing(String name, String description, double unitPrice, ProductUnit unit, ProductId productId) {
+    super(name, description, unitPrice, unit, productId)
   }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/Sequencing.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/Sequencing.groovy
@@ -21,7 +21,10 @@ class Sequencing extends AtomicProduct {
    * @param unit The product unit
    * @param productId The product identifier
    */
-  Sequencing(String name, String description, double unitPrice, ProductUnit unit, ProductId productId) {
-    super(name, description, unitPrice, unit, productId)
+
+  private static final String TYPE = "SE"
+
+  Sequencing(String name, String description, double unitPrice, ProductUnit unit, String identifier) {
+    super(name, description, unitPrice, unit, new ProductId(TYPE, identifier))
   }
 }

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/OfferSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/OfferSpec.groovy
@@ -30,8 +30,7 @@ class OfferSpec extends Specification {
         double overhead = 0.2
         double net = 900
         OfferId offerId = new OfferId("ab", "cd", "1")
-        ProductId productId = new ProductId("SE", "0")
-        ProductItem item = new ProductItem(2,new Sequencing("DNA Sequencing","This is a sequencing package",1.50, ProductUnit.PER_SAMPLE, productId))
+        ProductItem item = new ProductItem(2,new Sequencing("DNA Sequencing","This is a sequencing package",1.50, ProductUnit.PER_SAMPLE, "1"))
 
         when:
         Offer testOffer =

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/OfferSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/OfferSpec.groovy
@@ -30,7 +30,8 @@ class OfferSpec extends Specification {
         double overhead = 0.2
         double net = 900
         OfferId offerId = new OfferId("ab", "cd", "1")
-        ProductItem item = new ProductItem(2,new Sequencing("DNA Sequencing","This is a sequencing package",1.50, ProductUnit.PER_SAMPLE))
+        ProductId productId = new ProductId("SE", "0")
+        ProductItem item = new ProductItem(2,new Sequencing("DNA Sequencing","This is a sequencing package",1.50, ProductUnit.PER_SAMPLE, productId))
 
         when:
         Offer testOffer =

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/ProductItemSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/ProductItemSpec.groovy
@@ -14,8 +14,10 @@ class ProductItemSpec extends Specification {
 
 
     def "ProductItem shall store and provide the given properties: name, description and product"() {
+
         when:
-        Product product = new Sequencing("RNA Sequencing", "This package manages the pricing for all RNA sequencings", 1.0, ProductUnit.PER_SAMPLE)
+        ProductId productId = new ProductId("SE", "0")
+        Product product = new Sequencing("RNA Sequencing", "This package manages the pricing for all RNA sequencings", 1.0, ProductUnit.PER_SAMPLE, productId)
 
         def productItem = new ProductItem(3.0, product)
 
@@ -25,8 +27,9 @@ class ProductItemSpec extends Specification {
 
     def "Products shall be comparable"(){
         when:
-        Product product = new Sequencing("RNA Sequencing", "This package manages the pricing for all RNA sequencings", 1.0, ProductUnit.PER_SAMPLE)
-        Product product2 = new Sequencing("RNA Sequencing", "This package manages the pricing for all RNA sequencings", 1.0, ProductUnit.PER_SAMPLE)
+        ProductId productId = new ProductId("SE", "0")
+        Product product = new Sequencing("RNA Sequencing", "This package manages the pricing for all RNA sequencings", 1.0, ProductUnit.PER_SAMPLE, productId)
+        Product product2 = new Sequencing("RNA Sequencing", "This package manages the pricing for all RNA sequencings", 1.0, ProductUnit.PER_SAMPLE, productId)
 
         then:
         product == product2
@@ -34,7 +37,8 @@ class ProductItemSpec extends Specification {
 
     def "Product currency is euro"(){
         when:
-        Product product = new Sequencing("RNA Sequencing", "This package manages the pricing for all RNA sequencings", 1.0, ProductUnit.PER_SAMPLE)
+        ProductId productId = new ProductId("SE", "0")
+        Product product = new Sequencing("RNA Sequencing", "This package manages the pricing for all RNA sequencings", 1.0, ProductUnit.PER_SAMPLE, productId)
 
         then:
         product.currency.toString() == "EUR"

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/ProductItemSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/ProductItemSpec.groovy
@@ -16,8 +16,7 @@ class ProductItemSpec extends Specification {
     def "ProductItem shall store and provide the given properties: name, description and product"() {
 
         when:
-        ProductId productId = new ProductId("SE", "0")
-        Product product = new Sequencing("RNA Sequencing", "This package manages the pricing for all RNA sequencings", 1.0, ProductUnit.PER_SAMPLE, productId)
+        Product product = new Sequencing("RNA Sequencing", "This package manages the pricing for all RNA sequencings", 1.0, ProductUnit.PER_SAMPLE, "1")
 
         def productItem = new ProductItem(3.0, product)
 
@@ -27,18 +26,22 @@ class ProductItemSpec extends Specification {
 
     def "Products shall be comparable"(){
         when:
-        ProductId productId = new ProductId("SE", "0")
-        Product product = new Sequencing("RNA Sequencing", "This package manages the pricing for all RNA sequencings", 1.0, ProductUnit.PER_SAMPLE, productId)
-        Product product2 = new Sequencing("RNA Sequencing", "This package manages the pricing for all RNA sequencings", 1.0, ProductUnit.PER_SAMPLE, productId)
+
+        Product product = new Sequencing("RNA Sequencing", "This package manages the pricing for all RNA sequencings", 1.0, ProductUnit.PER_SAMPLE, "1")
+        Product product2 = new Sequencing("RNA Sequencing", "This package manages the pricing for all RNA sequencings", 1.0, ProductUnit.PER_SAMPLE, "1")
 
         then:
-        product == product2
+        product.currency == product2.currency
+        product.description == product2.description
+        product.productName == product2.productName
+        product.unit == product2.unit
+        product.unitPrice == product2.unitPrice
+        product.productId.toString() == product2.productId.toString()
     }
 
     def "Product currency is euro"(){
         when:
-        ProductId productId = new ProductId("SE", "0")
-        Product product = new Sequencing("RNA Sequencing", "This package manages the pricing for all RNA sequencings", 1.0, ProductUnit.PER_SAMPLE, productId)
+        Product product = new Sequencing("RNA Sequencing", "This package manages the pricing for all RNA sequencings", 1.0, ProductUnit.PER_SAMPLE, "1")
 
         then:
         product.currency.toString() == "EUR"


### PR DESCRIPTION
Description of changes
This PR is necessary to address Issue [#275 ](https://github.com/qbicsoftware/offer-manager-2-portlet/issues/275) of the offer-manager-2-portlet.
It adds the ProductId DTO and includes it in all product DTOs and adapts the testing accordingly.

Additional context
I also introduced the ProductId column to the product table in the database