### PR TITLE
Include and adapt dependencies to allow report-generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,25 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
+    <pluginRepositories>
+        <pluginRepository>
+            <id>maven-central-plugins</id>
+            <url>
+                https://repo.maven.apache.org/maven2
+            </url>
+        </pluginRepository>
+        <pluginRepository>
+            <id>liferay-releases-plugins</id>
+            <url>
+                https://repository.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/portal/
+            </url>
+        </pluginRepository>
+        <pluginRepository>
+            <id>qbic-plugins-2</id>
+            <url>https://qbic-repo.qbic.uni-tuebingen.de/repository/maven-releases</url>
+        </pluginRepository>
+    </pluginRepositories>
+
 	<!-- we only need to tell maven where to find our parent pom and other QBiC dependencies -->
 	<repositories>
 		<repository>

--- a/pom.xml
+++ b/pom.xml
@@ -23,18 +23,6 @@
 
     <pluginRepositories>
         <pluginRepository>
-            <id>maven-central-plugins</id>
-            <url>
-                https://repo.maven.apache.org/maven2
-            </url>
-        </pluginRepository>
-        <pluginRepository>
-            <id>liferay-releases-plugins</id>
-            <url>
-                https://repository.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/portal/
-            </url>
-        </pluginRepository>
-        <pluginRepository>
             <id>qbic-plugins-2</id>
             <url>https://qbic-repo.qbic.uni-tuebingen.de/repository/maven-releases</url>
         </pluginRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -68,30 +68,30 @@
             <url>https://jitpack.io</url>
         </repository>
 	</repositories>
-
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>org.codehaus.groovy</groupId>
                 <artifactId>groovy-bom</artifactId>
-                <version>3.0.6</version>
+                <version>3.0.7</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+          <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>3.0.7</version>
+            <type>pom</type>
+            <scope>${osgi.scope}</scope>
+          </dependency>
         </dependencies>
     </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>osgi.core</artifactId>
             <version>7.0.0</version>
             <scope>${osgi.scope}</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy</artifactId>
-            <scope>provided</scope>
         </dependency>
         <!-- JSON schema validator -->
         <dependency>
@@ -128,7 +128,6 @@
           <scope>test</scope>
       </dependency>
     </dependencies>
-
      <distributionManagement>
       <repository>
         <uniqueVersion>true</uniqueVersion>
@@ -162,7 +161,7 @@
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.11.0</version>
+                <version>1.12.0</version>
                 <executions>
                     <execution>
                         <goals>
@@ -177,10 +176,47 @@
                             <goal>removeTestStubs</goal>
                         </goals>
                     </execution>
+                  <execution>
+                    <id>site</id>
+                    <phase>site</phase>
+                    <goals>
+                      <goal>generateStubs</goal>
+                      <goal>generateTestStubs</goal>
+                      <goal>groovydoc</goal>
+                      <goal>groovydocTests</goal>
+                    </goals>
+                  </execution>
                 </executions>
+              <configuration>
+                <groovyDocOutputDirectory>${project.build.directory}/site/gapidocs</groovyDocOutputDirectory>
+                <testGroovyDocOutputDirectory>${project.build.directory}/site/testgapidocs</testGroovyDocOutputDirectory>
+              </configuration>
             </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-site-plugin</artifactId>
+            <version>3.7.1</version>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-project-info-reports-plugin</artifactId>
+            <version>3.0.0</version>
+          </plugin>
+          <plugin>
+            <groupId>life.qbic</groupId>
+            <artifactId>groovydoc-maven-plugin</artifactId>
+            <version>1.0.2</version>
+          </plugin>
         </plugins>
     </build>
+  <reporting>
+    <plugins>
+    <plugin>
+    <groupId>life.qbic</groupId>
+    <artifactId>groovydoc-maven-plugin</artifactId>
+  </plugin>
+  </plugins>
+</reporting>
   <profiles>
     <profile>
       <id>no-liferay</id>


### PR DESCRIPTION
Description of changes
This PR intends to solve the issue #145 in context of the groovydoc report generation:

1. Add the `Maven Site`plugin and `maven-project-info-reports-plugin` to the `pom.xml` to ensure that the build runs in Github Actions.
2. Adding the `groovy-all` dependency with a set versioning since GMavenPlus needs the an explicit setting of groovy.
3 Enable the correct groovydoc generation during the site generation by adding the `site execution` setting to `GMavenPlus plugin` in the parent module `pom.xml` .
4 Additionally the `GroovydocOutput` property has to set for the GmavenPlus Plugin, so it's generated in the target/site directory
5. Adding the `groovydoc-maven-plugin` to the reporting section of the `pom.xml `to enable the linkage from the project summary page to the generated gapidocs.
6. Include the current Nexus to the `plugin repository` section of the `pom.xml.` Otherwise maven won't know where to look for the `groovydoc-maven-plugin`