### PR TITLE
Refactor/#275 implement product

### DIFF
--- a/src/main/groovy/life/qbic/datamodel/dtos/business/ProductId.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/ProductId.groovy
@@ -18,12 +18,12 @@ class ProductId {
     /**
      * The type of the identifier is defined by the implementing identifier
      */
-    final private String type
+    private final String type
 
     /**
      * Identifying number used in conjunction with the type
      */
-    final private String identifier
+    private final String identifier
 
     /**
      * Creates an identifier object with the

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/DataStorage.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/DataStorage.groovy
@@ -19,10 +19,10 @@ class DataStorage extends PartialProduct {
    * @param description The description of what the product is about.
    * @param unitPrice The price in € per unit
    * @param unit The product unit
-   * @param productId The product identifier
+   * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
    */
 
-  DataStorage(String name, String description, double unitPrice, ProductUnit unit, String identifier) {
-    super(name, description, unitPrice, unit, new ProductId(ProductType.DATA_STORAGE.toString(), identifier))
+  DataStorage(String name, String description, double unitPrice, ProductUnit unit, String runningNumber) {
+    super(name, description, unitPrice, unit, new ProductId(ProductType.DATA_STORAGE.toString(), runningNumber))
   }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/DataStorage.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/DataStorage.groovy
@@ -22,9 +22,7 @@ class DataStorage extends PartialProduct {
    * @param productId The product identifier
    */
 
-  private static final String TYPE = "DS"
-
   DataStorage(String name, String description, double unitPrice, ProductUnit unit, String identifier) {
-    super(name, description, unitPrice, unit, new ProductId(TYPE, identifier))
+    super(name, description, unitPrice, unit, new ProductId(ProductType.DATA_STORAGE.toString(), identifier))
   }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/PrimaryAnalysis.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/PrimaryAnalysis.groovy
@@ -19,10 +19,10 @@ class PrimaryAnalysis extends AtomicProduct {
    * @param description The description of what the product is about.
    * @param unitPrice The price in € per unit
    * @param unit The product unit
-   * @param productId The product identifier
+   * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
    */
 
-  PrimaryAnalysis(String name, String description, double unitPrice, ProductUnit unit, String identifier) {
-    super(name, description, unitPrice, unit, new ProductId(ProductType.PRIMARY_BIOINFO.toString(), identifier))
+  PrimaryAnalysis(String name, String description, double unitPrice, ProductUnit unit, String runningNumber) {
+    super(name, description, unitPrice, unit, new ProductId(ProductType.PRIMARY_BIOINFO.toString(), runningNumber))
   }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/PrimaryAnalysis.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/PrimaryAnalysis.groovy
@@ -22,9 +22,7 @@ class PrimaryAnalysis extends AtomicProduct {
    * @param productId The product identifier
    */
 
-  private static final String TYPE = "PB"
-
   PrimaryAnalysis(String name, String description, double unitPrice, ProductUnit unit, String identifier) {
-    super(name, description, unitPrice, unit, new ProductId(TYPE, identifier))
+    super(name, description, unitPrice, unit, new ProductId(ProductType.PRIMARY_BIOINFO.toString(), identifier))
   }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProductType.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProductType.groovy
@@ -1,0 +1,47 @@
+package life.qbic.datamodel.dtos.business.services
+
+/**
+ * Lists the abbreviation for each Product used as a type specification
+ * by the ProductIdentifier {@link life.qbic.datamodel.dtos.business.ProductId}
+ *
+ * @since: 1.13.0
+ */
+
+enum ProductType {
+
+    SEQUENCING("SE"),
+    PROJECT_MANAGEMENT("PM"),
+    PRIMARY_BIOINFO("PB"),
+    SECONDARY_BIOINFO("SB"),
+    DATA_STORAGE("DS")
+
+    /**
+     Holds the String value of the enum
+     */
+    private final String value
+
+    /**
+     * Private constructor to create different ProductType enum items
+     * @param value
+     */
+    private ProductType(String value) {
+        this.value = value
+    }
+
+    /**
+     * Returns to the enum item value
+     * @return
+     */
+    String getValue() {
+        return value
+    }
+
+    /**
+     * Returns a String representation of the enum item
+     * @return
+     */
+    @Override
+    String toString() {
+        return this.getValue()
+    }
+}

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProjectManagement.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProjectManagement.groovy
@@ -19,10 +19,10 @@ class ProjectManagement extends PartialProduct {
    * @param description The description of what the product is about.
    * @param unitPrice The price in € per unit
    * @param unit The product unit
-   * @param productId The product identifier
+   * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
    */
 
-  ProjectManagement(String name, String description, double unitPrice, ProductUnit unit, String identifier) {
-    super(name, description, unitPrice, unit, new ProductId(ProductType.PROJECT_MANAGEMENT.toString(), identifier))
+  ProjectManagement(String name, String description, double unitPrice, ProductUnit unit, String runningNumber) {
+    super(name, description, unitPrice, unit, new ProductId(ProductType.PROJECT_MANAGEMENT.toString(), runningNumber))
   }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProjectManagement.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProjectManagement.groovy
@@ -22,9 +22,7 @@ class ProjectManagement extends PartialProduct {
    * @param productId The product identifier
    */
 
-  private static final String TYPE = "PM"
-
   ProjectManagement(String name, String description, double unitPrice, ProductUnit unit, String identifier) {
-    super(name, description, unitPrice, unit, new ProductId(TYPE, identifier))
+    super(name, description, unitPrice, unit, new ProductId(ProductType.PROJECT_MANAGEMENT.toString(), identifier))
   }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/SecondaryAnalysis.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/SecondaryAnalysis.groovy
@@ -20,12 +20,12 @@ class SecondaryAnalysis extends AtomicProduct {
    * @param description The description of what the product is about.
    * @param unitPrice The price in € per unit
    * @param unit The product unit
-   * @param productId The product identifier
+   * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
    */
 
-  SecondaryAnalysis(String name, String description, double unitPrice, ProductUnit unit, String identifier) {
+  SecondaryAnalysis(String name, String description, double unitPrice, ProductUnit unit, String runningNumber) {
 
-    super(name, description, unitPrice, unit, new ProductId(ProductType.SECONDARY_BIOINFO.toString() , identifier))
+    super(name, description, unitPrice, unit, new ProductId(ProductType.SECONDARY_BIOINFO.toString() , runningNumber))
 
   }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/SecondaryAnalysis.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/SecondaryAnalysis.groovy
@@ -22,11 +22,10 @@ class SecondaryAnalysis extends AtomicProduct {
    * @param unit The product unit
    * @param productId The product identifier
    */
-  private static final String TYPE = "SB"
 
   SecondaryAnalysis(String name, String description, double unitPrice, ProductUnit unit, String identifier) {
 
-    super(name, description, unitPrice, unit, new ProductId(TYPE , identifier))
+    super(name, description, unitPrice, unit, new ProductId(ProductType.SECONDARY_BIOINFO.toString() , identifier))
 
   }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/Sequencing.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/Sequencing.groovy
@@ -22,9 +22,7 @@ class Sequencing extends AtomicProduct {
    * @param productId The product identifier
    */
 
-  private static final String TYPE = "SE"
-
   Sequencing(String name, String description, double unitPrice, ProductUnit unit, String identifier) {
-    super(name, description, unitPrice, unit, new ProductId(TYPE, identifier))
+    super(name, description, unitPrice, unit, new ProductId(ProductType.SEQUENCING.toString(), identifier))
   }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/Sequencing.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/Sequencing.groovy
@@ -19,10 +19,10 @@ class Sequencing extends AtomicProduct {
    * @param description The description of what the product is about.
    * @param unitPrice The price in € per unit
    * @param unit The product unit
-   * @param productId The product identifier
+   * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
    */
 
-  Sequencing(String name, String description, double unitPrice, ProductUnit unit, String identifier) {
-    super(name, description, unitPrice, unit, new ProductId(ProductType.SEQUENCING.toString(), identifier))
+  Sequencing(String name, String description, double unitPrice, ProductUnit unit, String runningNumber) {
+    super(name, description, unitPrice, unit, new ProductId(ProductType.SEQUENCING.toString(), runningNumber))
   }
 }


### PR DESCRIPTION
**Description of changes**
This PR refactors the variables contained in `ProductId` and introduces a seperate `ProductType` Enum to avoid static typing on a product level. 

**Additional context**
It is intended as a follow up PR to #146 
