### PR TITLE
Decrease groovy version to 2.5.10 to avoid breaking changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,14 +80,14 @@
             <dependency>
                 <groupId>org.codehaus.groovy</groupId>
                 <artifactId>groovy-bom</artifactId>
-                <version>3.0.7</version>
+                <version>2.5.10</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
           <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>3.0.7</version>
+            <version>2.5.10</version>
             <type>pom</type>
             <scope>${osgi.scope}</scope>
           </dependency>
@@ -131,7 +131,7 @@
       <dependency>
           <groupId>org.spockframework</groupId>
           <artifactId>spock-core</artifactId>
-          <version>2.0-M4-groovy-3.0</version>
+          <version>1.3-groovy-2.5</version>
           <scope>test</scope>
       </dependency>
     </dependencies>
@@ -158,7 +158,7 @@
             </plugin>
           <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>3.0.0-M5</version>
+            <version>2.21.0</version>
             <configuration>
               <includes>
                 <include>**/*Spec</include>


### PR DESCRIPTION
Classes compiled with Groovy 3 are not compatible with groovy 2.5.10. Therefore `1.13.0` must still use Groovy `2.5.X`