### PR TITLE
Add List of ProductItems and their Net Prices associated with Overhead Pricing to Offer DTO 

### DIFF
--- a/src/main/groovy/life/qbic/datamodel/dtos/business/Offer.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/Offer.groovy
@@ -65,6 +65,14 @@ class Offer {
      */
     final Affiliation selectedCustomerAffiliation
 
+    final List<ProductItem> itemsWithOverhead
+
+    final List<ProductItem> itemsWithoutOverhead
+
+    final double itemsWithOverheadNetPrice
+
+    final double itemsWithoutOverheadNetPrice
+
     static class Builder {
 
         /*
@@ -78,7 +86,8 @@ class Offer {
         Date modificationDate
         Date expirationDate
         List<ProductItem> items
-
+        List<ProductItem> itemsWithOverhead
+        List<ProductItem> itemsWithoutOverhead
         /*
         Offer identifier
          */
@@ -91,6 +100,8 @@ class Offer {
         double netPrice
         double taxes
         double overheads
+        double itemsWithOverheadNet
+        double itemsWithoutOverheadNet
 
         Builder(Customer customer, ProjectManager projectManager, String projectTitle, String projectDescription, Affiliation selectedCustomerAffiliation) {
             this.customer = Objects.requireNonNull(customer, "Customer must not be null")
@@ -103,6 +114,10 @@ class Offer {
             overheads = 0
             taxes = 0
             totalPrice = 0
+            itemsWithOverhead = []
+            itemsWithoutOverhead = []
+            itemsWithOverheadNet = 0
+            itemsWithoutOverheadNet = 0
         }
 
         Builder modificationDate(Date modificationDate) {
@@ -160,6 +175,26 @@ class Offer {
             return this
         }
 
+        Builder itemsWithOverhead(List<ProductItem> itemsWithOverhead) {
+            this.itemsWithOverhead= itemsWithOverhead
+            return this
+        }
+
+        Builder itemsWithoutOverhead(List<ProductItem> itemsWithoutOverhead) {
+            this.itemsWithoutOverhead= itemsWithoutOverhead
+            return this
+        }
+
+        Builder itemsWithOverheadNet(double itemsWithOverheadNet) {
+            this.itemsWithOverheadNet = itemsWithOverheadNet
+            return this
+        }
+
+        Builder itemsWithoutOverheadNet(double itemsWithoutOverheadNet) {
+            this.itemsWithoutOverheadNet = itemsWithoutOverheadNet
+            return this
+        }
+
         Offer build() {
             return new Offer(this)
         }
@@ -179,6 +214,10 @@ class Offer {
         this.overheads = builder.overheads
         this.taxes = builder.taxes
         this.totalPrice = builder.totalPrice
+        this.itemsWithOverhead = builder.itemsWithOverhead
+        this.itemsWithoutOverhead = builder.itemsWithoutOverhead
+        this.itemsWithOverheadNetPrice = builder.itemsWithOverheadNet
+        this.itemsWithoutOverheadNetPrice = builder.itemsWithoutOverheadNet
     }
 
     /**

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/Offer.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/Offer.groovy
@@ -64,13 +64,21 @@ class Offer {
      * The affiliation of the customer selected for this offer
      */
     final Affiliation selectedCustomerAffiliation
-
+    /**
+     * A list of items for which an overhead cost is applicable
+     */
     final List<ProductItem> itemsWithOverhead
-
+    /**
+     * A list of Items for which an overhead cost is not applicable
+     */
     final List<ProductItem> itemsWithoutOverhead
-
+    /**
+     * The net price of all items for which an overhead cost is applicable, without overhead and taxes
+     */
     final double itemsWithOverheadNetPrice
-
+    /**
+     * The net price of all items for which an overhead cost is not applicable, without overhead and taxes
+     */
     final double itemsWithoutOverheadNetPrice
 
     static class Builder {

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/OfferSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/OfferSpec.groovy
@@ -31,11 +31,12 @@ class OfferSpec extends Specification {
         double net = 900
         OfferId offerId = new OfferId("ab", "cd", "1")
         ProductItem item = new ProductItem(2,new Sequencing("DNA Sequencing","This is a sequencing package",1.50, ProductUnit.PER_SAMPLE, "1"))
-
+        double itemsWithOverheadNet = 123
+        double itemsWithoutOverheadNet = 456
         when:
         Offer testOffer =
                 new Offer.Builder(customer, projectManager, "Archer", "Cartoon Series", selectedAffiliation)
-                        .modificationDate(date).expirationDate(date).totalPrice(price).identifier(offerId).taxes(vat).overheads(overhead).netPrice(net).items([item])
+                        .modificationDate(date).expirationDate(date).totalPrice(price).identifier(offerId).taxes(vat).overheads(overhead).netPrice(net).items([item]).itemsWithOverhead([item]).itemsWithoutOverhead([item]).itemsWithOverheadNet(itemsWithOverheadNet).itemsWithoutOverheadNet(itemsWithoutOverheadNet)
                         .build()
 
         then:
@@ -52,6 +53,10 @@ class OfferSpec extends Specification {
         testOffer.getTotalPrice() == price
         testOffer.getIdentifier() == offerId
         testOffer.getSelectedCustomerAffiliation() == selectedAffiliation
+        testOffer.getItemsWithOverhead() == [item]
+        testOffer.getItemsWithoutOverhead() == [item]
+        testOffer.getItemsWithOverheadNetPrice() == 123
+        testOffer.getItemsWithoutOverheadNetPrice() == 456
     }
 
     def "Missing optional Field definitions shall haven null values in an Offer object"() {


### PR DESCRIPTION
**Description of changes**
This PR Introduces 4 new Fields to the Offer DTO which are necessary fot the final Offer document. 

- List of ProductItems which are relevant for overhead calculation 
- List of ProductItems which are irrelevant for overhead calculation 
- Net value of ProductItems which are relevant for overhead calculation 
- Net value of ProductItems which are irrevelant for overhead calculation 

It also updates the Offer DTO Testing to account for the new fields. 

**Additional Information** 
Currently the final Offer just lists the ProductItems one after the other. The new version should be able to distinct the provided services into ProductItems with an associated Overhead cost and ProductItems without an associated Overhead cost. Therefore for both cases the netSum and ProductItem List should be transferable from the Offer entitity to the PDF Conversion 