### PR TITLE
Introduce OverheadRatio Property in Offer DTO 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,20 +11,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * ``life.qbic.datamodel.dtos.projectmanagement.ProjectIdentifier``, ``life.qbic.datamodel.dtos.projectmanagement.ProjectCode``, ``life.qbic.datamodel.dtos.projectmanagement.ProjectSpace`` and ``life.qbic.datamodel.dtos.projectmanagement.Project`` to describe QBiC projects
 * ``life.qbic.datamodel.dtos.projectmanagement.ProjectApplication`` to describe a project application for registration at QBiC's data management platform
-
-**Fixed**
-
-**Dependencies**
-
-**Deprecated**
-
-
-2.3.0-SNAPSHOT (2021-03-05)
----------------------------
-
-**Added**
-
-* overheadModifier property for ``life.qbic.datamodel.dtos.business.Offer``
+* ``life.qbic.datamodel.dtos.business.Offer#overheadModifier` property for ``life.qbic.datamodel.dtos.business.Offer```
 
 **Fixed**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,14 +4,15 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
-2.3.0
---------
+
+2.3.0-SNAPSHOT (2021-03-05)
+---------------------------
 
 **Added**
 
+* overheadModifier property for ``life.qbic.datamodel.dtos.business.Offer``
 * ``life.qbic.datamodel.dtos.projectmanagement.ProjectIdentifier``, ``life.qbic.datamodel.dtos.projectmanagement.ProjectCode``, ``life.qbic.datamodel.dtos.projectmanagement.ProjectSpace`` and ``life.qbic.datamodel.dtos.projectmanagement.Project`` to describe QBiC projects
 * ``life.qbic.datamodel.dtos.projectmanagement.ProjectApplication`` to describe a project application for registration at QBiC's data management platform
-* ``life.qbic.datamodel.dtos.business.Offer#overheadModifier` property for ``life.qbic.datamodel.dtos.business.Offer```
 
 **Fixed**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Added**
 
+* overheadModifier property for ``life.qbic.datamodel.dtos.business.Offer``
+
 **Fixed**
 
 **Dependencies**

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/Offer.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/Offer.groovy
@@ -92,9 +92,9 @@ class Offer {
      */
     final double itemsWithoutOverheadNetPrice
     /**
-     * The overhead modifier applied to the pricing dependent on the customer affiliation
+     * The overhead ratio applied to the pricing dependent on the customer affiliation
      */
-    final double overheadModifier
+    final double overheadRatio
 
     static class Builder {
 
@@ -126,7 +126,7 @@ class Offer {
         double overheads
         double itemsWithOverheadNet
         double itemsWithoutOverheadNet
-        double overheadModifier
+        double overheadRatio
         /**
          * @deprecated Replaced with {@link #projectObjective}, since 2.1.0
          */
@@ -155,7 +155,7 @@ class Offer {
             this.itemsWithOverheadNet = 0
             this.itemsWithoutOverheadNet = 0
             this.checksum = ""
-            this.overheadModifier = 0
+            this.overheadRatio = 0
 
             /*
             Deprecated
@@ -228,8 +228,8 @@ class Offer {
             return this
         }
 
-        Builder overheadModifier(double overheadModifier){
-            this.overheadModifier = overheadModifier
+        Builder overheadRatio(double overheadRatio){
+            this.overheadRatio = overheadRatio
             return this
         }
 
@@ -268,7 +268,7 @@ class Offer {
         this.itemsWithoutOverhead = builder.itemsWithoutOverhead
         this.itemsWithOverheadNetPrice = builder.itemsWithOverheadNet
         this.itemsWithoutOverheadNetPrice = builder.itemsWithoutOverheadNet
-        this.overheadModifier = builder.overheadModifier
+        this.overheadRatio = builder.overheadRatio
 
         /*
         Deprecated properties

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/Offer.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/Offer.groovy
@@ -91,6 +91,10 @@ class Offer {
      * The net price of all items for which an overhead cost is not applicable, without overhead and taxes
      */
     final double itemsWithoutOverheadNetPrice
+    /**
+     * The overhead modifier applied to the pricing dependent on the customer affiliation
+     */
+    final double overheadModifier
 
     static class Builder {
 
@@ -122,7 +126,7 @@ class Offer {
         double overheads
         double itemsWithOverheadNet
         double itemsWithoutOverheadNet
-
+        double overheadModifier
         /**
          * @deprecated Replaced with {@link #projectObjective}, since 2.1.0
          */
@@ -151,6 +155,7 @@ class Offer {
             this.itemsWithOverheadNet = 0
             this.itemsWithoutOverheadNet = 0
             this.checksum = ""
+            this.overheadModifier = 0
 
             /*
             Deprecated
@@ -223,6 +228,11 @@ class Offer {
             return this
         }
 
+        Builder overheadModifier(double overheadModifier){
+            this.overheadModifier = overheadModifier
+            return this
+        }
+
         Offer build() {
             return new Offer(this)
         }
@@ -258,6 +268,7 @@ class Offer {
         this.itemsWithoutOverhead = builder.itemsWithoutOverhead
         this.itemsWithOverheadNetPrice = builder.itemsWithOverheadNet
         this.itemsWithoutOverheadNetPrice = builder.itemsWithoutOverheadNet
+        this.overheadModifier = builder.overheadModifier
 
         /*
         Deprecated properties

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/OfferSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/OfferSpec.groovy
@@ -33,10 +33,11 @@ class OfferSpec extends Specification {
         ProductItem item = new ProductItem(2,new Sequencing("DNA Sequencing","This is a sequencing package",1.50, ProductUnit.PER_SAMPLE, "1"))
         double itemsWithOverheadNet = 123
         double itemsWithoutOverheadNet = 456
+        double overheadModifier = 0.2
         when:
         Offer testOffer =
                 new Offer.Builder(customer, projectManager, "Archer", "Cartoon Series", selectedAffiliation)
-                        .modificationDate(date).expirationDate(date).totalPrice(price).identifier(offerId).taxes(vat).overheads(overhead).netPrice(net).items([item]).itemsWithOverhead([item]).itemsWithoutOverhead([item]).itemsWithOverheadNet(itemsWithOverheadNet).itemsWithoutOverheadNet(itemsWithoutOverheadNet)
+                        .modificationDate(date).expirationDate(date).totalPrice(price).identifier(offerId).taxes(vat).overheads(overhead).netPrice(net).items([item]).itemsWithOverhead([item]).itemsWithoutOverhead([item]).itemsWithOverheadNet(itemsWithOverheadNet).itemsWithoutOverheadNet(itemsWithoutOverheadNet).overheadModifier(overheadModifier)
                         .build()
 
         then:
@@ -57,6 +58,7 @@ class OfferSpec extends Specification {
         testOffer.getItemsWithoutOverhead() == [item]
         testOffer.getItemsWithOverheadNetPrice() == 123
         testOffer.getItemsWithoutOverheadNetPrice() == 456
+        testOffer.overheadModifier == 0.2
     }
 
     def "Missing optional Field definitions shall haven null values in an Offer object"() {

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/OfferSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/OfferSpec.groovy
@@ -33,11 +33,11 @@ class OfferSpec extends Specification {
         ProductItem item = new ProductItem(2,new Sequencing("DNA Sequencing","This is a sequencing package",1.50, ProductUnit.PER_SAMPLE, "1"))
         double itemsWithOverheadNet = 123
         double itemsWithoutOverheadNet = 456
-        double overheadModifier = 0.2
+        double overheadRatio = 0.2
         when:
         Offer testOffer =
                 new Offer.Builder(customer, projectManager, "Archer", "Cartoon Series", selectedAffiliation)
-                        .modificationDate(date).expirationDate(date).totalPrice(price).identifier(offerId).taxes(vat).overheads(overhead).netPrice(net).items([item]).itemsWithOverhead([item]).itemsWithoutOverhead([item]).itemsWithOverheadNet(itemsWithOverheadNet).itemsWithoutOverheadNet(itemsWithoutOverheadNet).overheadModifier(overheadModifier)
+                        .modificationDate(date).expirationDate(date).totalPrice(price).identifier(offerId).taxes(vat).overheads(overhead).netPrice(net).items([item]).itemsWithOverhead([item]).itemsWithoutOverhead([item]).itemsWithOverheadNet(itemsWithOverheadNet).itemsWithoutOverheadNet(itemsWithoutOverheadNet).overheadRatio(overheadRatio)
                         .build()
 
         then:
@@ -58,7 +58,7 @@ class OfferSpec extends Specification {
         testOffer.getItemsWithoutOverhead() == [item]
         testOffer.getItemsWithOverheadNetPrice() == 123
         testOffer.getItemsWithoutOverheadNetPrice() == 456
-        testOffer.overheadModifier == 0.2
+        testOffer.overheadRatio == 0.2
     }
 
     def "Missing optional Field definitions shall haven null values in an Offer object"() {


### PR DESCRIPTION
- [X] This comment contains a description of changes (with reason)
- [X] Referenced issue is linked
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [Never!] Documentation in `docs` is updated
- [X] `CHANGELOG.rst` is updated

**Description of changes**
It was requested by the stakeholders to show the overhead percentage in the final Offer PDF. (See [#358](https://github.com/qbicsoftware/offer-manager-2-portlet/issues/358)) 
For this reason this PR introduces the overheadRatio property to the Offer DTO. 
The intent of this property is to store the applicable overhead markup, which is dependent on the customer affiliation. 