### PR TITLE
Move ProjectApplication from projectmanagement to business

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * overheadModifier property for ``life.qbic.datamodel.dtos.business.Offer``
 * ``life.qbic.datamodel.dtos.projectmanagement.ProjectIdentifier``, ``life.qbic.datamodel.dtos.projectmanagement.ProjectCode``, ``life.qbic.datamodel.dtos.projectmanagement.ProjectSpace`` and ``life.qbic.datamodel.dtos.projectmanagement.Project`` to describe QBiC projects
-* ``life.qbic.datamodel.dtos.projectmanagement.ProjectApplication`` to describe a project application for registration at QBiC's data management platform
+* ``life.qbic.datamodel.dtos.business.ProjectApplication`` to describe a project application for registration at QBiC's data management platform
 
 **Fixed**
 

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/ProjectApplication.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/ProjectApplication.groovy
@@ -1,8 +1,10 @@
-package life.qbic.datamodel.dtos.projectmanagement
+package life.qbic.datamodel.dtos.business
 
 import life.qbic.datamodel.dtos.business.Customer
 import life.qbic.datamodel.dtos.business.OfferId
 import life.qbic.datamodel.dtos.business.ProjectManager
+import life.qbic.datamodel.dtos.projectmanagement.ProjectCode
+import life.qbic.datamodel.dtos.projectmanagement.ProjectSpace
 
 /**
  * Information about a desired project registration in QBiC's project management system.


### PR DESCRIPTION


- [x] `CHANGELOG.rst` is updated

## Description of Changes
The ProjectApplication class was moved from projectmanagement to business. It is only applicable in the context of offers and therefore belongs in this package.
