### PR TITLE
Introduce "Proteomic" and "Metabolomic" Product DTOs, Types and Categories

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 * Added ``life.qbic.datamodel.samples.Status.SAMPLE_RECEIVED``, ``life.qbic.datamodel.samples.Status.LIBRARY_PREP_FINISHED``, ``life.qbic.datamodel.samples.Status.DATA_AVAILABLE`` sample statuses
 * Added optional property ``associatedProject`` to ``life.qbic.datamodel.dtos.business.Offer``
 * Added ``life.qbic.datamodel.dtos.business.ProductCategory.PROTEOMIC``, ``life.qbic.datamodel.dtos.business.ProductCategory.METABOLOMIC`` product categories
+* Added ``life.qbic.datamodel.dtos.business.services.ProductType.PROTEOMIC``, ``life.qbic.datamodel.dtos.business.services.ProductType.METABOLOMIC`` product types
 
 **Fixed**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 * Added optional property ``associatedProject`` to ``life.qbic.datamodel.dtos.business.Offer``
 * Added ``life.qbic.datamodel.dtos.business.ProductCategory.PROTEOMIC``, ``life.qbic.datamodel.dtos.business.ProductCategory.METABOLOMIC`` product categories
 * Added ``life.qbic.datamodel.dtos.business.services.ProductType.PROTEOMIC``, ``life.qbic.datamodel.dtos.business.services.ProductType.METABOLOMIC`` product types
+* Introduce ``life.qbic.datamodel.dtos.business.services.ProteomicAnalysis``, ``life.qbic.datamodel.dtos.business.services.MetabolomicAnalysis`` atomic products
 
 **Fixed**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * Added ``life.qbic.datamodel.samples.Status.SAMPLE_RECEIVED``, ``life.qbic.datamodel.samples.Status.LIBRARY_PREP_FINISHED``, ``life.qbic.datamodel.samples.Status.DATA_AVAILABLE`` sample statuses
 * Added optional property ``associatedProject`` to ``life.qbic.datamodel.dtos.business.Offer``
+* Added ``life.qbic.datamodel.dtos.business.ProductCategory.PROTEOMIC``, ``life.qbic.datamodel.dtos.business.ProductCategory.METABOLOMIC`` product categories
 
 **Fixed**
 

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/ProductCategory.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/ProductCategory.groovy
@@ -13,7 +13,9 @@ enum ProductCategory {
     PROJECT_MANAGEMENT("Project Management"),
     PRIMARY_BIOINFO("Primary Bioinformatics"),
     SECONDARY_BIOINFO("Secondary Bioinformatics"),
-    DATA_STORAGE("Data Storage")
+    DATA_STORAGE("Data Storage"),
+    PROTEOMIC("Proteomics"),
+    METABOLOMIC("Metabolomics")
 
     /**
      * Value describing the enum type with a string

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/MetabolomicAnalysis.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/MetabolomicAnalysis.groovy
@@ -1,0 +1,29 @@
+package life.qbic.datamodel.dtos.business.services
+
+import groovy.transform.EqualsAndHashCode
+import life.qbic.datamodel.dtos.business.ProductId
+
+/**
+ * Describes a product for metabolomic services.
+ *
+ * @since 2.4.0
+ */
+@EqualsAndHashCode(callSuper = true)
+class MetabolomicAnalysis extends AtomicProduct {
+   /**
+   * Basic product constructor.
+   *
+   * Checks that all passed arguments are not null.
+   *
+   * @param name The name of the product.
+   * @param description The description of what the product is about.
+   * @param unitPrice The price in € per unit
+   * @param unit The product unit
+   * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
+   */
+
+    MetabolomicAnalysis(String name, String description, double unitPrice, ProductUnit unit, String runningNumber) {
+      super(name, description, unitPrice, unit, new ProductId(ProductType.METABOLOMIC.toString(), runningNumber))
+    }
+}
+

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProductType.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProductType.groovy
@@ -13,7 +13,9 @@ enum ProductType {
     PROJECT_MANAGEMENT("PM"),
     PRIMARY_BIOINFO("PB"),
     SECONDARY_BIOINFO("SB"),
-    DATA_STORAGE("DS")
+    DATA_STORAGE("DS"),
+    PROTEOMIC("PR"),
+    METABOLOMIC("ME")
 
     /**
      Holds the String value of the enum

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProteomicAnalysis.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProteomicAnalysis.groovy
@@ -1,0 +1,28 @@
+package life.qbic.datamodel.dtos.business.services
+
+import groovy.transform.EqualsAndHashCode
+import life.qbic.datamodel.dtos.business.ProductId
+
+/**
+ * Describes a product for proteomic services.
+ *
+ * @since 2.4.0
+ */
+@EqualsAndHashCode(callSuper = true)
+class ProteomicAnalysis extends AtomicProduct {
+   /**
+   * Basic product constructor.
+   *
+   * Checks that all passed arguments are not null.
+   *
+   * @param name The name of the product.
+   * @param description The description of what the product is about.
+   * @param unitPrice The price in € per unit
+   * @param unit The product unit
+   * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
+   */
+
+    ProteomicAnalysis(String name, String description, double unitPrice, ProductUnit unit, String runningNumber) {
+        super(name, description, unitPrice, unit, new ProductId(ProductType.PROTEOMIC.toString(), runningNumber))
+    }
+}


### PR DESCRIPTION
- [X] This comment contains a description of changes (with reason)
- [X] `CHANGELOG.rst` is updated

**Description of changes**
This PR achieves 3 things: 

1. Introduces the `PROTEOMIC` and `METABOLOMIC` values to `ProductCategory` Enum
2. Introduces the `PROTEOMIC` and `METABOLOMIC` values to `ProductType` Enum
3. Introduces the `ProteomicAnalysis` and `MetabolomicAnalysis` DTOs 
