### PR TITLE
Fix equality check for service products

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Fixed**
 
+* Equals method is now properly overridden for ``life.qbic.datamodel.dtos.business.ProductId``
+
 **Dependencies**
 
 **Deprecated**

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/ProductId.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/ProductId.groovy
@@ -1,6 +1,7 @@
 package life.qbic.datamodel.dtos.business
 
 import groovy.transform.CompileStatic
+import groovy.transform.EqualsAndHashCode
 
 /**
  * A DTO describing Product Identifiers
@@ -11,8 +12,8 @@ import groovy.transform.CompileStatic
  * @since: 2.0.0
  *
  */
-
 @CompileStatic
+@EqualsAndHashCode
 class ProductId {
 
     /**

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/Product.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/Product.groovy
@@ -65,5 +65,4 @@ abstract class Product {
     this.currency = Currency.getInstance(Locale.GERMANY)
 
   }
-
 }

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/services/PrimaryAnalysisSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/services/PrimaryAnalysisSpec.groovy
@@ -3,11 +3,9 @@ package life.qbic.datamodel.dtos.business.services
 import spock.lang.Specification
 
 /**
- * <class short description - 1 Line!>
+ * Some tests for the primary analysis class
  *
- * <More detailed description - When to use, what it solves, etc.>
- *
- * @since <versiontag>
+ * @since 2.4.0
  */
 class PrimaryAnalysisSpec extends Specification{
 

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/services/PrimaryAnalysisSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/services/PrimaryAnalysisSpec.groovy
@@ -1,0 +1,39 @@
+package life.qbic.datamodel.dtos.business.services
+
+import spock.lang.Specification
+
+/**
+ * <class short description - 1 Line!>
+ *
+ * <More detailed description - When to use, what it solves, etc.>
+ *
+ * @since <versiontag>
+ */
+class PrimaryAnalysisSpec extends Specification{
+
+    def "Equality check shall return false for different primary analysis service products"() {
+        given: "two different products"
+        PrimaryAnalysis productOne = new PrimaryAnalysis("One", "", 0.0, ProductUnit.PER_GIGABYTE, "1")
+        PrimaryAnalysis productTwo = new PrimaryAnalysis("Two", "", 0.0, ProductUnit.PER_GIGABYTE,
+                "1")
+
+        when: "we compare these two"
+        def isEqualOneTwo = productOne.equals(productTwo)
+
+        then: "the should be not equal"
+        !isEqualOneTwo
+    }
+
+    def "Equality check shall return true for same primary analysis service products"() {
+        given: "two identical products, but two instances"
+        PrimaryAnalysis productOne = new PrimaryAnalysis("One", "", 0.0, ProductUnit.PER_GIGABYTE, "1")
+        PrimaryAnalysis productCopy = new PrimaryAnalysis("One", "", 0.0, ProductUnit.PER_GIGABYTE,
+                "1")
+
+        when: "we compare them"
+        def isEqual = productOne.equals(productCopy)
+
+        then: "they should be evaluated as equal"
+        isEqual
+    }
+}


### PR DESCRIPTION
Overrides the equals(Object obj) method for the `ProductId`.