### PR TITLE
Add product constructor with running number as long

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,12 +9,18 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 ---------------------------
 
 **Added**
+* New constructor using the new ``life.qbic.datamodel.dtos.business.ProductId`` constructor for ``life.qbic.datamodel.dtos.business.services.Sequencing``, ``life.qbic.datamodel.dtos.business.services.SecondaryAnalysis`,
+``life.qbic.datamodel.dtos.business.services.ProteomicAnalysis``, ``life.qbic.datamodel.dtos.business.services.ProjectManagement``, ``life.qbic.datamodel.dtos.business.services.PrimaryAnalysis`,
+``life.qbic.datamodel.dtos.business.services.MetabolomicAnalysis``, ``life.qbic.datamodel.dtos.business.services.DataStorage``
 
 **Fixed**
 
 **Dependencies**
 
 **Deprecated**
+* Constructor using the deprecated ``life.qbic.datamodel.dtos.business.ProductId`` constructor for ``life.qbic.datamodel.dtos.business.services.Sequencing``, ``life.qbic.datamodel.dtos.business.services.SecondaryAnalysis`,
+``life.qbic.datamodel.dtos.business.services.ProteomicAnalysis``, ``life.qbic.datamodel.dtos.business.services.ProjectManagement``, ``life.qbic.datamodel.dtos.business.services.PrimaryAnalysis`,
+``life.qbic.datamodel.dtos.business.services.MetabolomicAnalysis``, ``life.qbic.datamodel.dtos.business.services.DataStorage``
 
 
 2.4.0 (2021-03-18)

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/DataStorage.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/DataStorage.groovy
@@ -21,8 +21,22 @@ class DataStorage extends PartialProduct {
    * @param unit The product unit
    * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
    */
-
   DataStorage(String name, String description, double unitPrice, ProductUnit unit, String runningNumber) {
     super(name, description, unitPrice, unit, new ProductId(ProductType.DATA_STORAGE.toString(), runningNumber))
+  }
+
+  /**
+   * Basic product constructor.
+   *
+   * Checks that all passed arguments are not null.
+   *
+   * @param name The name of the product.
+   * @param description The description of what the product is about.
+   * @param unitPrice The price in € per unit
+   * @param unit The product unit
+   * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
+   */
+  DataStorage(String name, String description, double unitPrice, ProductUnit unit, long runningNumber) {
+    super(name, description, unitPrice, unit, new ProductId.Builder(ProductType.DATA_STORAGE.toString(), runningNumber).build())
   }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/DataStorage.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/DataStorage.groovy
@@ -20,7 +20,9 @@ class DataStorage extends PartialProduct {
    * @param unitPrice The price in € per unit
    * @param unit The product unit
    * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
+   * @deprecated since 2.5.0
    */
+  @Deprecated
   DataStorage(String name, String description, double unitPrice, ProductUnit unit, String runningNumber) {
     super(name, description, unitPrice, unit, new ProductId(ProductType.DATA_STORAGE.toString(), runningNumber))
   }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/MetabolomicAnalysis.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/MetabolomicAnalysis.groovy
@@ -4,7 +4,7 @@ import groovy.transform.EqualsAndHashCode
 import life.qbic.datamodel.dtos.business.ProductId
 
 /**
- * Describes a product for metabolomic services.
+ * Describes a product for metabolomics services.
  *
  * @since 2.4.0
  */
@@ -21,9 +21,23 @@ class MetabolomicAnalysis extends AtomicProduct {
    * @param unit The product unit
    * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
    */
-
     MetabolomicAnalysis(String name, String description, double unitPrice, ProductUnit unit, String runningNumber) {
       super(name, description, unitPrice, unit, new ProductId(ProductType.METABOLOMIC.toString(), runningNumber))
+    }
+
+    /**
+     * Basic product constructor.
+     *
+     * Checks that all passed arguments are not null.
+     *
+     * @param name The name of the product.
+     * @param description The description of what the product is about.
+     * @param unitPrice The price in € per unit
+     * @param unit The product unit
+     * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
+     */
+    MetabolomicAnalysis(String name, String description, double unitPrice, ProductUnit unit, long runningNumber) {
+        super(name, description, unitPrice, unit, new ProductId.Builder(ProductType.METABOLOMIC.toString(), runningNumber).build())
     }
 }
 

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/MetabolomicAnalysis.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/MetabolomicAnalysis.groovy
@@ -11,16 +11,18 @@ import life.qbic.datamodel.dtos.business.ProductId
 @EqualsAndHashCode(callSuper = true)
 class MetabolomicAnalysis extends AtomicProduct {
    /**
-   * Basic product constructor.
-   *
-   * Checks that all passed arguments are not null.
-   *
-   * @param name The name of the product.
-   * @param description The description of what the product is about.
-   * @param unitPrice The price in € per unit
-   * @param unit The product unit
-   * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
-   */
+    * Basic product constructor.
+    *
+    * Checks that all passed arguments are not null.
+    *
+    * @param name The name of the product.
+    * @param description The description of what the product is about.
+    * @param unitPrice The price in € per unit
+    * @param unit The product unit
+    * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
+    * @deprecated since 2.5.0
+    */
+    @Deprecated
     MetabolomicAnalysis(String name, String description, double unitPrice, ProductUnit unit, String runningNumber) {
       super(name, description, unitPrice, unit, new ProductId(ProductType.METABOLOMIC.toString(), runningNumber))
     }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/PrimaryAnalysis.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/PrimaryAnalysis.groovy
@@ -21,8 +21,22 @@ class PrimaryAnalysis extends AtomicProduct {
    * @param unit The product unit
    * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
    */
-
   PrimaryAnalysis(String name, String description, double unitPrice, ProductUnit unit, String runningNumber) {
     super(name, description, unitPrice, unit, new ProductId(ProductType.PRIMARY_BIOINFO.toString(), runningNumber))
+  }
+
+  /**
+   * Basic product constructor.
+   *
+   * Checks that all passed arguments are not null.
+   *
+   * @param name The name of the product.
+   * @param description The description of what the product is about.
+   * @param unitPrice The price in € per unit
+   * @param unit The product unit
+   * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
+   */
+  PrimaryAnalysis(String name, String description, double unitPrice, ProductUnit unit, long runningNumber) {
+    super(name, description, unitPrice, unit, new ProductId.Builder(ProductType.PRIMARY_BIOINFO.toString(), runningNumber).build())
   }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/PrimaryAnalysis.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/PrimaryAnalysis.groovy
@@ -20,7 +20,9 @@ class PrimaryAnalysis extends AtomicProduct {
    * @param unitPrice The price in € per unit
    * @param unit The product unit
    * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
+   * @deprecated since 2.5.0
    */
+  @Deprecated
   PrimaryAnalysis(String name, String description, double unitPrice, ProductUnit unit, String runningNumber) {
     super(name, description, unitPrice, unit, new ProductId(ProductType.PRIMARY_BIOINFO.toString(), runningNumber))
   }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProjectManagement.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProjectManagement.groovy
@@ -20,7 +20,9 @@ class ProjectManagement extends PartialProduct {
    * @param unitPrice The price in € per unit
    * @param unit The product unit
    * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
+   * @deprecated since 2.5.0
    */
+  @Deprecated
   ProjectManagement(String name, String description, double unitPrice, ProductUnit unit, String runningNumber) {
     super(name, description, unitPrice, unit, new ProductId(ProductType.PROJECT_MANAGEMENT.toString(), runningNumber))
   }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProjectManagement.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProjectManagement.groovy
@@ -21,8 +21,22 @@ class ProjectManagement extends PartialProduct {
    * @param unit The product unit
    * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
    */
-
   ProjectManagement(String name, String description, double unitPrice, ProductUnit unit, String runningNumber) {
     super(name, description, unitPrice, unit, new ProductId(ProductType.PROJECT_MANAGEMENT.toString(), runningNumber))
+  }
+
+  /**
+   * Basic product constructor.
+   *
+   * Checks that all passed arguments are not null.
+   *
+   * @param name The name of the product.
+   * @param description The description of what the product is about.
+   * @param unitPrice The price in € per unit
+   * @param unit The product unit
+   * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
+   */
+  ProjectManagement(String name, String description, double unitPrice, ProductUnit unit, long runningNumber) {
+    super(name, description, unitPrice, unit, new ProductId.Builder(ProductType.PROJECT_MANAGEMENT.toString(), runningNumber).build())
   }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProteomicAnalysis.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProteomicAnalysis.groovy
@@ -4,12 +4,13 @@ import groovy.transform.EqualsAndHashCode
 import life.qbic.datamodel.dtos.business.ProductId
 
 /**
- * Describes a product for proteomic services.
+ * Describes a product for proteomics services.
  *
  * @since 2.4.0
  */
 @EqualsAndHashCode(callSuper = true)
 class ProteomicAnalysis extends AtomicProduct {
+
    /**
    * Basic product constructor.
    *
@@ -21,8 +22,22 @@ class ProteomicAnalysis extends AtomicProduct {
    * @param unit The product unit
    * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
    */
-
     ProteomicAnalysis(String name, String description, double unitPrice, ProductUnit unit, String runningNumber) {
         super(name, description, unitPrice, unit, new ProductId(ProductType.PROTEOMIC.toString(), runningNumber))
+    }
+
+    /**
+     * Basic product constructor.
+     *
+     * Checks that all passed arguments are not null.
+     *
+     * @param name The name of the product.
+     * @param description The description of what the product is about.
+     * @param unitPrice The price in € per unit
+     * @param unit The product unit
+     * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
+     */
+    ProteomicAnalysis(String name, String description, double unitPrice, ProductUnit unit, long runningNumber) {
+        super(name, description, unitPrice, unit, new ProductId.Builder(ProductType.PROTEOMIC.toString(), runningNumber).build())
     }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProteomicAnalysis.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProteomicAnalysis.groovy
@@ -12,16 +12,18 @@ import life.qbic.datamodel.dtos.business.ProductId
 class ProteomicAnalysis extends AtomicProduct {
 
    /**
-   * Basic product constructor.
-   *
-   * Checks that all passed arguments are not null.
-   *
-   * @param name The name of the product.
-   * @param description The description of what the product is about.
-   * @param unitPrice The price in € per unit
-   * @param unit The product unit
-   * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
-   */
+    * Basic product constructor.
+    *
+    * Checks that all passed arguments are not null.
+    *
+    * @param name The name of the product.
+    * @param description The description of what the product is about.
+    * @param unitPrice The price in € per unit
+    * @param unit The product unit
+    * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
+    * @deprecated since 2.5.0
+    */
+    @Deprecated
     ProteomicAnalysis(String name, String description, double unitPrice, ProductUnit unit, String runningNumber) {
         super(name, description, unitPrice, unit, new ProductId(ProductType.PROTEOMIC.toString(), runningNumber))
     }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/SecondaryAnalysis.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/SecondaryAnalysis.groovy
@@ -22,10 +22,22 @@ class SecondaryAnalysis extends AtomicProduct {
    * @param unit The product unit
    * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
    */
-
   SecondaryAnalysis(String name, String description, double unitPrice, ProductUnit unit, String runningNumber) {
-
     super(name, description, unitPrice, unit, new ProductId(ProductType.SECONDARY_BIOINFO.toString() , runningNumber))
+  }
 
+  /**
+   * Basic product constructor.
+   *
+   * Checks that all passed arguments are not null.
+   *
+   * @param name The name of the product.
+   * @param description The description of what the product is about.
+   * @param unitPrice The price in € per unit
+   * @param unit The product unit
+   * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
+   */
+  SecondaryAnalysis(String name, String description, double unitPrice, ProductUnit unit, long runningNumber) {
+    super(name, description, unitPrice, unit, new ProductId.Builder(ProductType.SECONDARY_BIOINFO.toString(), runningNumber).build())
   }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/SecondaryAnalysis.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/SecondaryAnalysis.groovy
@@ -21,7 +21,9 @@ class SecondaryAnalysis extends AtomicProduct {
    * @param unitPrice The price in € per unit
    * @param unit The product unit
    * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
+   * @deprecated since 2.5.0
    */
+  @Deprecated
   SecondaryAnalysis(String name, String description, double unitPrice, ProductUnit unit, String runningNumber) {
     super(name, description, unitPrice, unit, new ProductId(ProductType.SECONDARY_BIOINFO.toString() , runningNumber))
   }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/Sequencing.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/Sequencing.groovy
@@ -25,4 +25,19 @@ class Sequencing extends AtomicProduct {
   Sequencing(String name, String description, double unitPrice, ProductUnit unit, String runningNumber) {
     super(name, description, unitPrice, unit, new ProductId(ProductType.SEQUENCING.toString(), runningNumber))
   }
+
+  /**
+   * Basic product constructor.
+   *
+   * Checks that all passed arguments are not null.
+   *
+   * @param name The name of the product.
+   * @param description The description of what the product is about.
+   * @param unitPrice The price in € per unit
+   * @param unit The product unit
+   * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
+   */
+  Sequencing(String name, String description, double unitPrice, ProductUnit unit, long runningNumber) {
+    super(name, description, unitPrice, unit, new ProductId.Builder(ProductType.SEQUENCING.toString(), runningNumber).build())
+  }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/Sequencing.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/Sequencing.groovy
@@ -20,8 +20,9 @@ class Sequencing extends AtomicProduct {
    * @param unitPrice The price in € per unit
    * @param unit The product unit
    * @param runningNumber Number used in conjunction with ProductType{@link life.qbic.datamodel.dtos.business.services.ProductType} to identify product
+   * @deprecated 2.5.0
    */
-
+  @Deprecated
   Sequencing(String name, String description, double unitPrice, ProductUnit unit, String runningNumber) {
     super(name, description, unitPrice, unit, new ProductId(ProductType.SEQUENCING.toString(), runningNumber))
   }


### PR DESCRIPTION
**Purpose**
The product classes still used the old constructor for building the product id, the new builder pattern with the running number as a long should be used.

**Changes**
A new constructor is added for each class. The old constructor is deprecated and the changes are logged in the CL