### PR TITLE
Remove deprectation from sampel tracking classes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,20 +9,24 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 ---------------------------
 
 **Added**
-* New constructor using the new ``life.qbic.datamodel.dtos.business.ProductId`` constructor for ``life.qbic.datamodel.dtos.business.services.Sequencing``, ``life.qbic.datamodel.dtos.business.services.SecondaryAnalysis`,
-``life.qbic.datamodel.dtos.business.services.ProteomicAnalysis``, ``life.qbic.datamodel.dtos.business.services.ProjectManagement``, ``life.qbic.datamodel.dtos.business.services.PrimaryAnalysis`,
-``life.qbic.datamodel.dtos.business.services.MetabolomicAnalysis``, ``life.qbic.datamodel.dtos.business.services.DataStorage``
+
+* New constructor using the new ``life.qbic.datamodel.dtos.business.ProductId`` constructor for ``life.qbic.datamodel.dtos.business.services.Sequencing``, ``life.qbic.datamodel.dtos.business.services.SecondaryAnalysis``,
+  ``life.qbic.datamodel.dtos.business.services.ProteomicAnalysis``, ``life.qbic.datamodel.dtos.business.services.ProjectManagement``, ``life.qbic.datamodel.dtos.business.services.PrimaryAnalysis``,
+  ``life.qbic.datamodel.dtos.business.services.MetabolomicAnalysis``, ``life.qbic.datamodel.dtos.business.services.DataStorage``
 
 **Fixed**
-* Override ``equals()`` method for ``life.qbic.datamodel.dtos.business.OfferId` and ``life.qbic
-.datamodel.dtos.business.TomatoId``properly
+
+* Override ``equals()`` method for ``life.qbic.datamodel.dtos.business.OfferId`` and
+  ``life.qbic.datamodel.dtos.business.TomatoId`` properly
 
 **Dependencies**
 
 **Deprecated**
-* Constructor using the deprecated ``life.qbic.datamodel.dtos.business.ProductId`` constructor for ``life.qbic.datamodel.dtos.business.services.Sequencing``, ``life.qbic.datamodel.dtos.business.services.SecondaryAnalysis`,
-``life.qbic.datamodel.dtos.business.services.ProteomicAnalysis``, ``life.qbic.datamodel.dtos.business.services.ProjectManagement``, ``life.qbic.datamodel.dtos.business.services.PrimaryAnalysis`,
-``life.qbic.datamodel.dtos.business.services.MetabolomicAnalysis``, ``life.qbic.datamodel.dtos.business.services.DataStorage``
+
+* Constructor using the deprecated ``life.qbic.datamodel.dtos.business.ProductId`` constructor for ``life.qbic.datamodel.dtos.business.services.Sequencing``, ``life.qbic.datamodel.dtos.business.services.SecondaryAnalysis``,
+  ``life.qbic.datamodel.dtos.business.services.ProteomicAnalysis``, ``life.qbic.datamodel.dtos.business.services.ProjectManagement``, ``life.qbic.datamodel.dtos.business.services.PrimaryAnalysis``,
+  ``life.qbic.datamodel.dtos.business.services.MetabolomicAnalysis``, ``life.qbic.datamodel.dtos.business.services.DataStorage``
+* Removed Deprecation for ``life.qbic.datamodel.people.*``
 
 
 2.4.0 (2021-03-18)

--- a/src/main/groovy/life/qbic/datamodel/people/Address.groovy
+++ b/src/main/groovy/life/qbic/datamodel/people/Address.groovy
@@ -2,7 +2,6 @@ package life.qbic.datamodel.people
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
-@Deprecated
 class Address  {
 
   private String affiliation = ""

--- a/src/main/groovy/life/qbic/datamodel/people/Person.groovy
+++ b/src/main/groovy/life/qbic/datamodel/people/Person.groovy
@@ -1,6 +1,5 @@
 package life.qbic.datamodel.people;
 
-@Deprecated
 class Person {
 
   private String firstName


### PR DESCRIPTION
The classes cannot be replaced by any other class in the data-model-lib. Thus deprecation can be removed and was wrong in the first place. (I did it, sorry)


- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.rst` is updated
