### PR TITLE
Feature/add unknown product category

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
   ``life.qbic.datamodel.dtos.business.services.ProteomicAnalysis``, ``life.qbic.datamodel.dtos.business.services.ProjectManagement``, ``life.qbic.datamodel.dtos.business.services.PrimaryAnalysis``,
   ``life.qbic.datamodel.dtos.business.services.MetabolomicAnalysis``, ``life.qbic.datamodel.dtos.business.services.DataStorage``
 
+* Add Product Category ``life.qbic.datamodel.dtos.business.ProductCategory.UNKNOWN``
+
 **Fixed**
 
 * Override ``equals()`` method for ``life.qbic.datamodel.dtos.business.OfferId`` and

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/ProductCategory.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/ProductCategory.groovy
@@ -5,7 +5,7 @@ package life.qbic.datamodel.dtos.business
  *
  * A package can be of different types, they can be differentiated by the items that they contain
  *
- * @since: 1.0
+ * @since 1.0
  */
 enum ProductCategory {
 
@@ -15,7 +15,15 @@ enum ProductCategory {
     SECONDARY_BIOINFO("Secondary Bioinformatics"),
     DATA_STORAGE("Data Storage"),
     PROTEOMIC("Proteomics"),
-    METABOLOMIC("Metabolomics")
+    METABOLOMIC("Metabolomics"),
+    /**
+     * Unknown category is used for all products that could not be matched to
+     * another category. It is the default value if no assignment could be made.
+     * <p><b><em>Do not use to categorize products intentionally.</em></b></p>
+     * @since 2.5.0
+     */
+    UNKNOWN("Unknown")
+
 
     /**
      * Value describing the enum type with a string


### PR DESCRIPTION
Many thanks for contributing to this project!
Addresses https://github.com/qbicsoftware/offer-manager-2-portlet/issues/443

**PR Checklist**
Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

- [x] This comment contains a description of changes (with reason)
- [x] Referenced issue is linked
- [x] `CHANGELOG.rst` is updated

**Description of changes**
There currently is no default value for the product category. For applications that might lead to errors in case the database contains values that are not reflected in the ProductCategory enum. For those cases, I introduce an `UNKNOWN` category that should only be used in case the category received is not reflected by the other enum values. Is this the case, then the applications have to make sure to handle products with unknown category correctly.

