### PR TITLE
Add experimental design offer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * New EnumFactory ``life.qbic.datamodel.dtos.business.ProductCategoryFactory`` (`#192 <https://github.com/qbicsoftware/data-model-lib/pull/192>`_)
 
+* New property experimentalDesign for ``life.qbic.datamodel.dtos.business.Offer``
+
 **Fixed**
 
 * Override ``equals()`` method for ``life.qbic.datamodel.dtos.business.OfferId`` and

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/Offer.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/Offer.groovy
@@ -183,38 +183,6 @@ class Offer {
             this.projectDescription = Objects.requireNonNull(projectObjective, "Project Objective must not be null")
         }
 
-        Builder(Customer customer, ProjectManager projectManager, String projectTitle, String projectObjective, String experimentalDesign, Affiliation selectedCustomerAffiliation) {
-            /*
-            Overall offer describing properties
-             */
-            this.customer = Objects.requireNonNull(customer, "Customer must not be null")
-            this.projectManager = Objects.requireNonNull(projectManager, "Project Manager must not be null")
-            this.projectTitle = Objects.requireNonNull(projectTitle, "Project Title must not be null")
-            this.projectObjective = Objects.requireNonNull(projectObjective, "Project Objective must not be null")
-            this.experimentalDesign = Objects.requireNonNull(experimentalDesign, "Experimental Design must not be null")
-            this.selectedCustomerAffiliation = Objects.requireNonNull(selectedCustomerAffiliation, "Customer Affiliation must not be null")
-            this.items = []
-
-            /*
-            Price related properties
-            */
-            this.netPrice = 0
-            this.overheads = 0
-            this.taxes = 0
-            this.totalPrice = 0
-            this.itemsWithOverhead = []
-            this.itemsWithoutOverhead = []
-            this.itemsWithOverheadNet = 0
-            this.itemsWithoutOverheadNet = 0
-            this.checksum = ""
-            this.overheadRatio = 0
-
-            /*
-            Project related
-             */
-            this.associatedProject = Optional.empty()
-        }
-
         Builder checksum(String checksum) {
             this.checksum = checksum
             return this

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/Offer.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/Offer.groovy
@@ -51,7 +51,7 @@ class Offer {
     /**
      * The experimental design of a project
      */
-    final String experimentalDesign
+    final Optional<String> experimentalDesign
     /**
      * A list of items for which the customer will be charged
      */
@@ -112,7 +112,7 @@ class Offer {
          */
         String projectTitle
         String projectObjective
-        String experimentalDesign
+        Optional<String> experimentalDesign
         Customer customer
         ProjectManager projectManager
         Affiliation selectedCustomerAffiliation
@@ -154,7 +154,7 @@ class Offer {
             this.projectManager = Objects.requireNonNull(projectManager, "Project Manager must not be null")
             this.projectTitle = Objects.requireNonNull(projectTitle, "Project Title must not be null")
             this.projectObjective = Objects.requireNonNull(projectObjective, "Project Objective must not be null")
-            this.experimentalDesign = ""
+            this.experimentalDesign = Optional.empty()
             this.selectedCustomerAffiliation = Objects.requireNonNull(selectedCustomerAffiliation, "Customer Affiliation must not be null")
             this.items = []
 
@@ -259,7 +259,7 @@ class Offer {
         }
 
         Builder experimentalDesign(String experimentalDesign){
-            this.experimentalDesign = experimentalDesign
+            this.experimentalDesign = Optional.of(experimentalDesign)
             return this
         }
 
@@ -278,10 +278,16 @@ class Offer {
         this.projectManager = builder.projectManager
         this.projectObjective = builder.projectObjective
         this.projectTitle = builder.projectTitle
-        this.experimentalDesign = builder.experimentalDesign
         this.selectedCustomerAffiliation = builder.selectedCustomerAffiliation
         this.items = builder.items
         this.checksum = builder.checksum
+
+        if (builder.experimentalDesign.isPresent()) {
+            this.experimentalDesign = builder.experimentalDesign
+        } else {
+            this.experimentalDesign = Optional.empty()
+        }
+
 
         /*
         Offer Identifier

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/Offer.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/Offer.groovy
@@ -49,6 +49,10 @@ class Offer {
      */
     final String projectObjective
     /**
+     * The experimental design of a project
+     */
+    final String experimentalDesign
+    /**
      * A list of items for which the customer will be charged
      */
     final List<ProductItem> items
@@ -108,6 +112,7 @@ class Offer {
          */
         String projectTitle
         String projectObjective
+        String experimentalDesign
         Customer customer
         ProjectManager projectManager
         Affiliation selectedCustomerAffiliation
@@ -149,6 +154,7 @@ class Offer {
             this.projectManager = Objects.requireNonNull(projectManager, "Project Manager must not be null")
             this.projectTitle = Objects.requireNonNull(projectTitle, "Project Title must not be null")
             this.projectObjective = Objects.requireNonNull(projectObjective, "Project Objective must not be null")
+            this.experimentalDesign = ""
             this.selectedCustomerAffiliation = Objects.requireNonNull(selectedCustomerAffiliation, "Customer Affiliation must not be null")
             this.items = []
 
@@ -175,6 +181,38 @@ class Offer {
             Deprecated
              */
             this.projectDescription = Objects.requireNonNull(projectObjective, "Project Objective must not be null")
+        }
+
+        Builder(Customer customer, ProjectManager projectManager, String projectTitle, String projectObjective, String experimentalDesign, Affiliation selectedCustomerAffiliation) {
+            /*
+            Overall offer describing properties
+             */
+            this.customer = Objects.requireNonNull(customer, "Customer must not be null")
+            this.projectManager = Objects.requireNonNull(projectManager, "Project Manager must not be null")
+            this.projectTitle = Objects.requireNonNull(projectTitle, "Project Title must not be null")
+            this.projectObjective = Objects.requireNonNull(projectObjective, "Project Objective must not be null")
+            this.experimentalDesign = Objects.requireNonNull(experimentalDesign, "Experimental Design must not be null")
+            this.selectedCustomerAffiliation = Objects.requireNonNull(selectedCustomerAffiliation, "Customer Affiliation must not be null")
+            this.items = []
+
+            /*
+            Price related properties
+            */
+            this.netPrice = 0
+            this.overheads = 0
+            this.taxes = 0
+            this.totalPrice = 0
+            this.itemsWithOverhead = []
+            this.itemsWithoutOverhead = []
+            this.itemsWithOverheadNet = 0
+            this.itemsWithoutOverheadNet = 0
+            this.checksum = ""
+            this.overheadRatio = 0
+
+            /*
+            Project related
+             */
+            this.associatedProject = Optional.empty()
         }
 
         Builder checksum(String checksum) {
@@ -252,6 +290,11 @@ class Offer {
             return this
         }
 
+        Builder experimentalDesign(String experimentalDesign){
+            this.experimentalDesign = experimentalDesign
+            return this
+        }
+
         Offer build() {
             return new Offer(this)
         }
@@ -267,6 +310,7 @@ class Offer {
         this.projectManager = builder.projectManager
         this.projectObjective = builder.projectObjective
         this.projectTitle = builder.projectTitle
+        this.experimentalDesign = builder.experimentalDesign
         this.selectedCustomerAffiliation = builder.selectedCustomerAffiliation
         this.items = builder.items
         this.checksum = builder.checksum

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/OfferSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/OfferSpec.groovy
@@ -37,7 +37,10 @@ class OfferSpec extends Specification {
         when:
         Offer testOffer =
                 new Offer.Builder(customer, projectManager, "Archer", "Cartoon Series", selectedAffiliation)
-                        .modificationDate(date).expirationDate(date).totalPrice(price).identifier(offerId).taxes(vat).overheads(overhead).netPrice(net).items([item]).itemsWithOverhead([item]).itemsWithoutOverhead([item]).itemsWithOverheadNet(itemsWithOverheadNet).itemsWithoutOverheadNet(itemsWithoutOverheadNet).overheadRatio(overheadRatio)
+                        .modificationDate(date).expirationDate(date).totalPrice(price).identifier(offerId).taxes(vat).overheads(overhead).netPrice(net).items([item])
+                        .itemsWithOverhead([item]).itemsWithoutOverhead([item]).itemsWithOverheadNet(itemsWithOverheadNet)
+                        .itemsWithoutOverheadNet(itemsWithoutOverheadNet).overheadRatio(overheadRatio)
+                        .experimentalDesign("design")
                         .build()
 
         then:
@@ -47,6 +50,7 @@ class OfferSpec extends Specification {
         testOffer.getProjectManager() == projectManager
         testOffer.getProjectTitle() == "Archer"
         testOffer.getProjectObjective() == "Cartoon Series"
+        testOffer.getExperimentalDesign() == "design"
         testOffer.getTaxes() == vat
         testOffer.getOverheads() == overhead
         testOffer.getNetPrice() == net
@@ -78,6 +82,31 @@ class OfferSpec extends Specification {
         testOffer.getProjectManager() == projectManager
         testOffer.getProjectTitle() == "Archer"
         testOffer.getProjectObjective() == "Cartoon Series"
+        testOffer.getItems() == []
+        testOffer.getTotalPrice() == 0
+        testOffer.getIdentifier() == null
+        testOffer.getSelectedCustomerAffiliation() == selectedAffiliation
+    }
+
+
+    def "Two builder constructors work"() {
+
+        given:
+        OfferId offerId = new OfferId("ab", "cd", "1")
+
+        when:
+        Offer testOffer =
+                new Offer.Builder(customer, projectManager, "Archer", "Cartoon Series", "Experimental Design",selectedAffiliation)
+                        .build()
+
+        then:
+        testOffer.getModificationDate() == null
+        testOffer.getExpirationDate() == null
+        testOffer.getCustomer() == customer
+        testOffer.getProjectManager() == projectManager
+        testOffer.getProjectTitle() == "Archer"
+        testOffer.getProjectObjective() == "Cartoon Series"
+        testOffer.experimentalDesign == "Experimental Design"
         testOffer.getItems() == []
         testOffer.getTotalPrice() == 0
         testOffer.getIdentifier() == null

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/OfferSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/OfferSpec.groovy
@@ -50,7 +50,7 @@ class OfferSpec extends Specification {
         testOffer.getProjectManager() == projectManager
         testOffer.getProjectTitle() == "Archer"
         testOffer.getProjectObjective() == "Cartoon Series"
-        testOffer.getExperimentalDesign() == "design"
+        testOffer.getExperimentalDesign().get() == "design"
         testOffer.getTaxes() == vat
         testOffer.getOverheads() == overhead
         testOffer.getNetPrice() == net

--- a/src/test/groovy/life/qbic/datamodel/dtos/business/OfferSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/business/OfferSpec.groovy
@@ -88,29 +88,4 @@ class OfferSpec extends Specification {
         testOffer.getSelectedCustomerAffiliation() == selectedAffiliation
     }
 
-
-    def "Two builder constructors work"() {
-
-        given:
-        OfferId offerId = new OfferId("ab", "cd", "1")
-
-        when:
-        Offer testOffer =
-                new Offer.Builder(customer, projectManager, "Archer", "Cartoon Series", "Experimental Design",selectedAffiliation)
-                        .build()
-
-        then:
-        testOffer.getModificationDate() == null
-        testOffer.getExpirationDate() == null
-        testOffer.getCustomer() == customer
-        testOffer.getProjectManager() == projectManager
-        testOffer.getProjectTitle() == "Archer"
-        testOffer.getProjectObjective() == "Cartoon Series"
-        testOffer.experimentalDesign == "Experimental Design"
-        testOffer.getItems() == []
-        testOffer.getTotalPrice() == 0
-        testOffer.getIdentifier() == null
-        testOffer.getSelectedCustomerAffiliation() == selectedAffiliation
-    }
-
 }


### PR DESCRIPTION
This PR adds the property experimental design in the context of [#263](https://github.com/qbicsoftware/offer-manager-2-portlet/issues/263).

The offer builder has been adapted and also the test extended. Furthermore, also the changelog has been updated.