### PR TITLE
Feature/update pipeline schema

### DIFF
--- a/src/main/resources/schemas/bioinformatics-analysis-result-set.schema.json
+++ b/src/main/resources/schemas/bioinformatics-analysis-result-set.schema.json
@@ -123,6 +123,7 @@
   "properties": {
     "pipelineInformation": {"$ref": "#/definitions/pipelineInformation"},
     "qualityControl": {"$ref":  "#/definitions/qualityControl"},
+    "processFolders": {"$ref":  "#/definitions/processFolders"},
     "runID": {"$ref":  "#/definitions/runID"},
     "inputIDs": {"$ref":  "#/definitions/inputIDs"}
   },

--- a/src/main/resources/schemas/bioinformatics-analysis-result-set.schema.json
+++ b/src/main/resources/schemas/bioinformatics-analysis-result-set.schema.json
@@ -94,7 +94,7 @@
         },
         {
           "properties": {
-            "name": { "pattern": "runId"},
+            "name": { "pattern": "run_id"},
             "fileType": { "pattern": "txt" }
           }
         }
@@ -109,7 +109,7 @@
         {
           "properties": {
             "name": {
-              "pattern": "runId"
+              "pattern": "input_ids"
             },
             "fileType": {
               "pattern": "txt"

--- a/src/main/resources/schemas/bioinformatics-analysis-result-set.schema.json
+++ b/src/main/resources/schemas/bioinformatics-analysis-result-set.schema.json
@@ -85,16 +85,52 @@
       "type": "array",
       "items": { "$ref": "data-structure-commons.json#/definitions/dataFolder" },
       "minItems": 1
+    },
+    "runID": {
+      "description": "A data file that contains the runId.",
+      "allOf": [
+        {
+          "$ref": "data-structure-commons.json#/definitions/dataFile"
+        },
+        {
+          "properties": {
+            "name": { "pattern": "runId"},
+            "fileType": { "pattern": "txt" }
+          }
+        }
+      ]
+    },
+    "inputIDs": {
+      "description": "A data file that contains the sample identifiers, which served as input data for the analysis run.",
+      "allOf": [
+        {
+          "$ref": "data-structure-commons.json#/definitions/dataFile"
+        },
+        {
+          "properties": {
+            "name": {
+              "pattern": "runId"
+            },
+            "fileType": {
+              "pattern": "txt"
+            }
+          }
+        }
+      ]
     }
   },
   "type": "object",
   "properties": {
     "pipelineInformation": {"$ref": "#/definitions/pipelineInformation"},
-    "qualityControl": {"$ref":  "#/definitions/qualityControl"}
+    "qualityControl": {"$ref":  "#/definitions/qualityControl"},
+    "runID": {"$ref":  "#/definitions/runID"},
+    "inputIDs": {"$ref":  "#/definitions/inputIDs"}
   },
   "required": [
     "pipelineInformation",
     "qualityControl",
-    "processFolders"
+    "processFolders",
+    "inputIDs",
+    "runID"
   ]
 }

--- a/src/main/resources/schemas/bioinformatics-analysis-result-set.schema.json
+++ b/src/main/resources/schemas/bioinformatics-analysis-result-set.schema.json
@@ -124,14 +124,14 @@
     "pipelineInformation": {"$ref": "#/definitions/pipelineInformation"},
     "qualityControl": {"$ref":  "#/definitions/qualityControl"},
     "processFolders": {"$ref":  "#/definitions/processFolders"},
-    "runID": {"$ref":  "#/definitions/runID"},
-    "inputIDs": {"$ref":  "#/definitions/inputIDs"}
+    "runID": {"$ref":  "#/definitions/runId"},
+    "inputIDs": {"$ref":  "#/definitions/sampleIds"}
   },
   "required": [
     "pipelineInformation",
     "qualityControl",
     "processFolders",
-    "inputIDs",
-    "runID"
+    "sampleIds",
+    "runId"
   ]
 }

--- a/src/main/resources/schemas/bioinformatics-analysis-result-set.schema.json
+++ b/src/main/resources/schemas/bioinformatics-analysis-result-set.schema.json
@@ -86,7 +86,7 @@
       "items": { "$ref": "data-structure-commons.json#/definitions/dataFolder" },
       "minItems": 1
     },
-    "runID": {
+    "runId": {
       "description": "A data file that contains the runId.",
       "allOf": [
         {
@@ -100,7 +100,7 @@
         }
       ]
     },
-    "inputIDs": {
+    "sampleIds": {
       "description": "A data file that contains the sample identifiers, which served as input data for the analysis run.",
       "allOf": [
         {
@@ -109,7 +109,7 @@
         {
           "properties": {
             "name": {
-              "pattern": "input_ids"
+              "pattern": "sample_ids"
             },
             "fileType": {
               "pattern": "txt"

--- a/src/test/resources/examples/resultset/valid-resultset-example.json
+++ b/src/test/resources/examples/resultset/valid-resultset-example.json
@@ -1,7 +1,7 @@
 {
   "pipelineInformation": {
     "name": "pipeline_info",
-    "path": "./",
+    "path": "./pipeline_info",
     "children": [],
     "softwareVersions": {
       "name": "software_versions",
@@ -21,7 +21,7 @@
   },
   "qualityControl": {
     "name": "multiqc",
-    "path": "./",
+    "path": "./multiqc",
     "children": [
       {
         "name": "star_salmon",
@@ -39,7 +39,7 @@
   "processFolders": [
     {
       "name": "salmon",
-      "path": "./",
+      "path": "./salmon",
       "children": [
         {
           "name": "salmon.merged.gene_tpm",

--- a/src/test/resources/examples/resultset/valid-resultset-example.json
+++ b/src/test/resources/examples/resultset/valid-resultset-example.json
@@ -6,17 +6,17 @@
     "softwareVersions": {
       "name": "software_versions",
       "fileType": "csv",
-      "path": "pipeline_info/software_versions"
+      "path": "./pipeline_info/software_versions.csv"
     },
     "pipelineReport": {
       "name": "pipeline_report",
       "fileType": "txt",
-      "path": "pipeline_info/pipeline_report"
+      "path": "./pipeline_info/pipeline_report.txt"
     },
     "executionReport": {
       "name": "execution_report",
       "fileType": "txt",
-      "path": "pipeline_info/execution_report"
+      "path": "./pipeline_info/execution_report.txt"
     }
   },
   "qualityControl": {
@@ -25,11 +25,11 @@
     "children": [
       {
         "name": "star_salmon",
-        "path": "multiqc/star_salmon",
+        "path": "./multiqc/star_salmon",
         "children": [
           {
             "name": "multiqc_report.html",
-            "path": "multiqc/star_salmon/multiqc_report.html",
+            "path": "./multiqc/star_salmon/multiqc_report.html",
             "fileType": "html"
           }
         ]
@@ -44,9 +44,19 @@
         {
           "name": "salmon.merged.gene_tpm",
           "fileType": "tsv",
-          "path": "salmon/salmon.merged.gene_tpm"
+          "path": "./salmon/salmon.merged.gene_tpm"
         }
       ]
     }
-  ]
+  ],
+  "runID": {
+    "name": "run_id",
+    "fileType": "txt",
+    "path": "./run_id.txt"
+  },
+  "inputIDs": {
+    "name": "input_ids",
+    "fileType": "txt",
+    "path": "./input_ids.txt"
+  }
 }

--- a/src/test/resources/examples/resultset/valid-resultset-example.json
+++ b/src/test/resources/examples/resultset/valid-resultset-example.json
@@ -49,14 +49,14 @@
       ]
     }
   ],
-  "runID": {
+  "runId": {
     "name": "run_id",
     "fileType": "txt",
     "path": "./run_id.txt"
   },
-  "inputIDs": {
-    "name": "input_ids",
+  "sampleIds": {
+    "name": "sample_ids",
     "fileType": "txt",
-    "path": "./input_ids.txt"
+    "path": "./sample_ids.txt"
   }
 }


### PR DESCRIPTION
This PR updates the JSON schema for bioinformatic analysis run output.

The additions address the two additional files we need to check, which are the

- input_ids.txt
- run_id.txt

files. The `input_ids.txt` will hold a list of sample ids, that reference the datasets that have been used for the analysis. The `run_id` contains the unique Nextflow Tower run id that identifies the pipeline run.