### PR TITLE
Remove @CompileStatic annotation to fix productId tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 * Override ``equals()`` method for ``life.qbic.datamodel.dtos.business.OfferId`` and
   ``life.qbic.datamodel.dtos.business.TomatoId`` properly
 
+* Remove @CompileStatic annotation from ProductId to enable builder pattern usage during compilation (`#186 <https://github.com/qbicsoftware/data-model-lib/issues/186>`_)
+
 **Dependencies**
 
 **Deprecated**

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/ProductId.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/ProductId.groovy
@@ -11,7 +11,6 @@ import groovy.transform.EqualsAndHashCode
  * @since: 2.0.0
  *
  */
-
 @EqualsAndHashCode
 class ProductId {
 

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/ProductId.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/ProductId.groovy
@@ -1,6 +1,5 @@
 package life.qbic.datamodel.dtos.business
 
-import groovy.transform.CompileStatic
 import groovy.transform.EqualsAndHashCode
 
 /**
@@ -12,7 +11,7 @@ import groovy.transform.EqualsAndHashCode
  * @since: 2.0.0
  *
  */
-@CompileStatic
+
 @EqualsAndHashCode
 class ProductId {
 


### PR DESCRIPTION
- [X] This comment contains a description of changes (with reason)
- [X] Referenced issue is linked

**Description of changes**
Addresses #186 by removing the `@CompileStatic` Annotation from the ProductId Class. 

**Technical details**
Apparently the Builder pattern is not compatible with the `@CompileStatic` Annotation(see [here](https://stackoverflow.com/a/14959481)), however it could theoretically be possible with the groovy `@Builder` annotation(See [here](https://dzone.com/articles/groovy-goodness-builder)) 

