### PR TITLE
Introduce Unspecified Files for nfCore Parser

### DIFF
--- a/src/main/groovy/life/qbic/datamodel/datasets/datastructure/files/nfcore/UnspecifiedFile.groovy
+++ b/src/main/groovy/life/qbic/datamodel/datasets/datastructure/files/nfcore/UnspecifiedFile.groovy
@@ -1,0 +1,30 @@
+package life.qbic.datamodel.datasets.datastructure.files.nfcore
+
+import life.qbic.datamodel.datasets.datastructure.files.DataFile
+
+/**
+ * A specialisation of a DataFile, represents a non-specified/variable output file in the nf-core Pipeline
+ *
+ * @since 2.7.0
+ */
+class UnspecifiedFile extends DataFile {
+
+    protected UnspecifiedFile() {}
+
+    protected UnspecifiedFile(String name, String relativePath, String fileType) {
+        super(name, relativePath, fileType)
+    }
+
+    /**
+     * Creates the Unspecified File object based on the provided fileName and its relative path
+     * @param name The file name of the unspecified file
+     * @param relativePath The relative path to the file in a file system
+     * @param fileType The file type of the unspecified file
+     * @return the UnspecifiedFile Object
+     * @since 2.7.0
+     */
+    static UnspecifiedFile create(String name, String relativePath, String fileType) {
+        return new UnspecifiedFile(name, relativePath, fileType)
+    }
+
+}

--- a/src/test/groovy/life/qbic/datamodel/datasets/datastructure/files/nfcore/UnspecifiedFileSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/datasets/datastructure/files/nfcore/UnspecifiedFileSpec.groovy
@@ -11,8 +11,8 @@ class UnspecifiedFileSpec extends Specification {
 
     def "shall create an UnspecifiedFile instance"() {
         given:
-        final name = "DummyFile"
-        final relativePath = "root/DummyFile"
+        final name = "DummyFile.txt"
+        final relativePath = "root/DummyFile.txt"
 
         when:
         def dataObject = UnspecifiedFile.create(name, relativePath, "txt")

--- a/src/test/groovy/life/qbic/datamodel/datasets/datastructure/files/nfcore/UnspecifiedFileSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/datasets/datastructure/files/nfcore/UnspecifiedFileSpec.groovy
@@ -1,0 +1,26 @@
+package life.qbic.datamodel.datasets.datastructure.files.nfcore
+
+import spock.lang.Specification
+
+/**
+ * Test for the UnspecifiedFile class
+ *
+ * @since 2.7.0
+ */
+class UnspecifiedFileSpec extends Specification {
+
+    def "shall create an UnspecifiedFile instance"() {
+        given:
+        final name = "DummyFile"
+        final relativePath = "root/DummyFile"
+
+        when:
+        def dataObject = UnspecifiedFile.create(name, relativePath, "txt")
+
+        then:
+        assert dataObject instanceof UnspecifiedFile
+        assert dataObject.relativePath == relativePath
+        assert dataObject.name == name
+    }
+
+}


### PR DESCRIPTION
- [X] This comment contains a description of changes (with reason)
- [X] `CHANGELOG.rst` is updated

**Description of changes**
This PR introduces the `UnspecifiedFile` class which extends the `DataFile` Object. 
This class will be used to represent files which can't be accounted for in the schema since they are dependent on the pipeline(e.g. the files in the subfolders of the `ProcessFolder` class). 

**Additional context**
I'm unsure if the class name could not be improved into something like `UnspecifedNfCoreFile` or something simliar. 
