### PR TITLE
Add pxp product units

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Added**
 
-* Add new product unit types to 'life.qbic.datamodel.dtos.business.services.ProductUnit' (`#215 <https://github.com/qbicsoftware/data-model-lib/pull/215>`_)
+* Add new product unit types to ``life.qbic.datamodel.dtos.business.services.ProductUnit`` (`#215 <https://github.com/qbicsoftware/data-model-lib/pull/215>`_)
 
   -   PER_HOUR("Hour"),
   -   PER_PROJECT("Project"),
@@ -23,7 +23,6 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
   -   PER_100_MICROGRAM_PEPTIDE_CHANNEL("100 microgram peptides channel"),
   -   PER_500_ML("500 milliliter"),
   -   PER_COMPARISON("Comparison")
-to 'life.qbic.datamodel.dtos.business.services.ProductUnit' (`#215 <https://github.com/qbicsoftware/data-model-lib/pull/215>`_)
 
 **Fixed**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,19 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Added**
 
-* Add new product unit types PER_PROJECT, PER_RUN, PER_CYCLE, PER_GEL, PER_MG, PER_MEASUREMENT, PER_CHANNEL, PER_PEPTIDE_CHANNEL, PER_ML, PER_COMPARISON
+* Add new product unit types to 'life.qbic.datamodel.dtos.business.services.ProductUnit' (`#215 <https://github.com/qbicsoftware/data-model-lib/pull/215>`_)
+
+  -   PER_HOUR("Hour"),
+  -   PER_PROJECT("Project"),
+  -   PER_RUN("Run"),
+  -   PER_CYCLE("Cycle"),
+  -   PER_GEL("Gel/HpH"),
+  -   PER_10_MG("10 milligram"),
+  -   PER_MEASUREMENT("Measurement"),
+  -   PER_CHANNEL("Channel"),
+  -   PER_100_MICROGRAM_PEPTIDE_CHANNEL("100 microgram peptides channel"),
+  -   PER_500_ML("500 milliliter"),
+  -   PER_COMPARISON("Comparison")
 to 'life.qbic.datamodel.dtos.business.services.ProductUnit' (`#215 <https://github.com/qbicsoftware/data-model-lib/pull/215>`_)
 
 **Fixed**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,9 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Added**
 
+* Add new product unit types PER_RUN, PER_CYCLE, PER_GEL, PER_MG, PER_MEASUREMENT, PER_CHANNEL, PER_PEPTIDE_CHANNEL, PER_ML, PER_COMPARISON
+to 'life.qbic.datamodel.dtos.business.services.ProductUnit' (`#215 <https://github.com/qbicsoftware/data-model-lib/pull/215>`_)
+
 **Fixed**
 
 **Dependencies**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Added**
 
-* Add new product unit types PER_RUN, PER_CYCLE, PER_GEL, PER_MG, PER_MEASUREMENT, PER_CHANNEL, PER_PEPTIDE_CHANNEL, PER_ML, PER_COMPARISON
+* Add new product unit types PER_PROJECT, PER_RUN, PER_CYCLE, PER_GEL, PER_MG, PER_MEASUREMENT, PER_CHANNEL, PER_PEPTIDE_CHANNEL, PER_ML, PER_COMPARISON
 to 'life.qbic.datamodel.dtos.business.services.ProductUnit' (`#215 <https://github.com/qbicsoftware/data-model-lib/pull/215>`_)
 
 **Fixed**

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProductUnit.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProductUnit.groovy
@@ -10,7 +10,16 @@ enum ProductUnit {
   PER_GIGABYTE("Gigabyte"),
   PER_SAMPLE("Sample"),
   PER_DATASET("Dataset"),
-  PER_HOUR("Hour")
+  PER_HOUR("Hour"),
+  PER_RUN("Run"),
+  PER_CYCLE("Cycle"),
+  PER_GEL("Gel/HpH"),
+  PER_MG("10 mg"),
+  PER_MEASUREMENT("Measurement"),
+  PER_CHANNEL("Channel"),
+  PER_PEPTIDE_CHANNEL("100 µg peptides channel"),
+  PER_ML("500 ml"),
+  PER_COMPARISON("COMPARISON")
 
   /**
    Holds the String value of the enum

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProductUnit.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProductUnit.groovy
@@ -20,7 +20,7 @@ enum ProductUnit {
   PER_CHANNEL("Channel"),
   PER_100_MICROGRAM_PEPTIDE_CHANNEL("100 microgram peptides channel"),
   PER_500_ML("500 milliliter"),
-  PER_COMPARISON("COMPARISON")
+  PER_COMPARISON("Comparison")
 
   /**
    Holds the String value of the enum

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProductUnit.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProductUnit.groovy
@@ -15,11 +15,11 @@ enum ProductUnit {
   PER_RUN("Run"),
   PER_CYCLE("Cycle"),
   PER_GEL("Gel/HpH"),
-  PER_MG("10 mg"),
+  PER_MG("10 Milligram"),
   PER_MEASUREMENT("Measurement"),
   PER_CHANNEL("Channel"),
-  PER_PEPTIDE_CHANNEL("100 µg peptides channel"),
-  PER_ML("500 ml"),
+  PER_PEPTIDE_CHANNEL("100 Microgram peptides channel"),
+  PER_ML("500 Milliliter"),
   PER_COMPARISON("COMPARISON")
 
   /**

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProductUnit.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProductUnit.groovy
@@ -11,6 +11,7 @@ enum ProductUnit {
   PER_SAMPLE("Sample"),
   PER_DATASET("Dataset"),
   PER_HOUR("Hour"),
+  PER_PROJECT("Project"),
   PER_RUN("Run"),
   PER_CYCLE("Cycle"),
   PER_GEL("Gel/HpH"),

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProductUnit.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProductUnit.groovy
@@ -15,11 +15,11 @@ enum ProductUnit {
   PER_RUN("Run"),
   PER_CYCLE("Cycle"),
   PER_GEL("Gel/HpH"),
-  PER_MG("10 Milligram"),
+  PER_10_MG("10 Milligram"),
   PER_MEASUREMENT("Measurement"),
   PER_CHANNEL("Channel"),
-  PER_PEPTIDE_CHANNEL("100 Microgram peptides channel"),
-  PER_ML("500 Milliliter"),
+  PER_100_MICROGRAM_PEPTIDE_CHANNEL("100 Microgram peptides channel"),
+  PER_500_ML("500 Milliliter"),
   PER_COMPARISON("COMPARISON")
 
   /**

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProductUnit.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProductUnit.groovy
@@ -15,11 +15,11 @@ enum ProductUnit {
   PER_RUN("Run"),
   PER_CYCLE("Cycle"),
   PER_GEL("Gel/HpH"),
-  PER_10_MG("10 Milligram"),
+  PER_10_MG("10 milligram"),
   PER_MEASUREMENT("Measurement"),
   PER_CHANNEL("Channel"),
-  PER_100_MICROGRAM_PEPTIDE_CHANNEL("100 Microgram peptides channel"),
-  PER_500_ML("500 Milliliter"),
+  PER_100_MICROGRAM_PEPTIDE_CHANNEL("100 microgram peptides channel"),
+  PER_500_ML("500 milliliter"),
   PER_COMPARISON("COMPARISON")
 
   /**


### PR DESCRIPTION
Adds the new product types for the proteomics platform:

-   PER_HOUR("Hour"),
-   PER_PROJECT("Project"),
-   PER_RUN("Run"),
-   PER_CYCLE("Cycle"),
-   PER_GEL("Gel/HpH"),
-   PER_10_MG("10 milligram"),
-   PER_MEASUREMENT("Measurement"),
-   PER_CHANNEL("Channel"),
-   PER_100_MICROGRAM_PEPTIDE_CHANNEL("100 microgram peptides channel"),
-   PER_500_ML("500 milliliter"),
-   PER_COMPARISON("Comparison")