### PR TITLE
Hotfix 2.12.1

### DIFF
--- a/.qube.yml
+++ b/.qube.yml
@@ -4,7 +4,7 @@ email: sven.fillinger@qbic.uni-tuebingen.de
 project_name: data-model-lib
 project_short_description: "Data models. A collection of QBiC's central data models\
   \ and DTOs. "
-version: 2.12.0
+version: 2.12.1
 domain: lib
 language: groovy
 project_slug: data-model-lib

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Fixed**
 
-* NPE when comparing ``life.qbic.datamodel.dtos.projectmanagement.ProjectIdentifier`` to null reference
+* NPE when comparing ``life.qbic.datamodel.dtos.projectmanagement.ProjectIdentifier`` to null reference (`#258 <https://github.com/qbicsoftware/data-model-lib/pull/258>`_)
 
 **Dependencies**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,19 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+2.12.1 (2021-09-13)
+-------------------
+
+**Added**
+
+**Fixed**
+
+* NPE when comparing ``life.qbic.datamodel.dtos.projectmanagement.ProjectIdentifier`` to null reference
+
+**Dependencies**
+
+**Deprecated**
+
 2.12.0 (2021-09-10)
 -------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>life.qbic</groupId>
 	<artifactId>data-model-lib</artifactId>
-	<version>2.12.0-SNAPSHOT</version> <!-- <<QUBE_FORCE_BUMP>> -->
+	<version>2.12.1-SNAPSHOT</version> <!-- <<QUBE_FORCE_BUMP>> -->
 	<name>data-model-lib</name>
 	<url>http://github.com/qbicsoftware/data-model-lib</url>
 	<description>Data models. A collection of QBiC's central data models and DTOs. </description>

--- a/src/main/groovy/life/qbic/datamodel/dtos/projectmanagement/ProjectIdentifier.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/projectmanagement/ProjectIdentifier.groovy
@@ -36,6 +36,9 @@ class ProjectIdentifier {
 
     @Override
     boolean equals(Object obj) {
+        if (obj == null) {
+            return false
+        }
         if (this.is(obj)) {
             return true
         }

--- a/src/test/groovy/life/qbic/datamodel/dtos/projectmanagement/ProjectIdentifierSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/projectmanagement/ProjectIdentifierSpec.groovy
@@ -40,6 +40,10 @@ class ProjectIdentifierSpec extends Specification{
 
     }
 
+    /**
+     * Tests for Joshua Bloch's Item 8 in Effective Java, how to override equals() properly.
+     * https://biratkirat.medium.com/learning-effective-java-item-8-d05f3847213d
+     */
     def "Test equals method fulfills full method contract"() {
         when:
         ProjectIdentifier idX = new ProjectIdentifier(new ProjectSpace(projectSpace), new ProjectCode(projectCode))

--- a/src/test/groovy/life/qbic/datamodel/dtos/projectmanagement/ProjectIdentifierSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/projectmanagement/ProjectIdentifierSpec.groovy
@@ -40,4 +40,22 @@ class ProjectIdentifierSpec extends Specification{
 
     }
 
+    def "Test equals method fulfills full method contract"() {
+        when:
+        ProjectIdentifier idX = new ProjectIdentifier(new ProjectSpace(projectSpace), new ProjectCode(projectCode))
+        ProjectIdentifier idY = new ProjectIdentifier(new ProjectSpace(projectSpace), new ProjectCode(projectCode))
+        ProjectIdentifier idZ = new ProjectIdentifier(new ProjectSpace(projectSpace), new ProjectCode(projectCode))
+
+        then:
+        idX.equals(idX) == true // Reflexive
+        (idX.equals(idY) == true) && (idY.equals(idX) == true) // Symmetric
+        (idX.equals(idY) == true) && (idY.equals(idZ) == true) && (idX.equals(idZ) == true) // Transitive
+        (idX.equals(idX) == true) && (idX.equals(idX) == true) // Consistent
+        idX.equals(null) == false // Non-nullity
+
+        where:
+        projectSpace | projectCode
+        "TEST" | "QTEST"
+    }
+
 }


### PR DESCRIPTION
Introduces an important fix that caused an NPE when comparing `life.qbic.datamodel.dtos.projectmanagement.ProjectIdentifier` to a null reference.

The expected return value is `false`, which is now introduced.