### PR TITLE
Add external service product

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 **Added**
 
 * Added new product type ``life.qbic.datamodel.dtos.business.services.ExternalServiceProduct`` (#262)
-* Added new ``Facility`` enum ``CEGAT`` (#262)
+* Added new ``Facility`` enum ``CEGAT`` in ``life.qbic.datamodel.dtos.business.facilities.Facility`` (#262)
 * Added new product type ``EXTERNAL_SERVICE`` for ``life.qbic.datamodel.dtos.business.ProductCategory`` (#262)
 
 **Fixed**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,9 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Added**
 
+* Added new product type ``life.qbic.datamodel.dtos.business.services.ExternalServiceProduct`` (#262)
+* Added new ``Facility`` enum ``CEGAT`` (#262)
+
 **Fixed**
 
 **Dependencies**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * Added new product type ``life.qbic.datamodel.dtos.business.services.ExternalServiceProduct`` (#262)
 * Added new ``Facility`` enum ``CEGAT`` (#262)
+* Added new product type ``EXTERNAL_SERVICE`` for ``life.qbic.datamodel.dtos.business.ProductCategory`` (#262)
 
 **Fixed**
 

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/ProductCategory.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/ProductCategory.groovy
@@ -15,7 +15,8 @@ enum ProductCategory {
     SECONDARY_BIOINFO("Secondary Bioinformatics"),
     DATA_STORAGE("Data Storage"),
     PROTEOMIC("Proteomics"),
-    METABOLOMIC("Metabolomics")
+    METABOLOMIC("Metabolomics"),
+    EXTERNAL_SERVICE("External Service")
 
     /**
      * Value describing the enum type with a string

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/facilities/Facility.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/facilities/Facility.groovy
@@ -10,7 +10,8 @@ package life.qbic.datamodel.dtos.business.facilities
  *     <li>IMGAG: Institute for Medical Genetics and Applied Genomics</li>
  *     <li>MGM: Institute for Medical Microbiology and Hygiene</li>
  *     <li>QBIC: Quantitative Biology Center</li>
- *     <li>PCT: Proteome Center Tübingen</li>
+ *     <li>CFMB_PCT: Proteomics Facility Tübingen</li>
+ *     <li>CEGAT: CeGaT GmbH</li>
  * </ul>
  *
  * @since 2.11.0
@@ -21,7 +22,8 @@ enum Facility {
     IMGAG("Institute for Medical Genetics and Applied Genomics", "IMGAG"),
     MGM("Institute for Medical Microbiology and Hygiene", "MGM"),
     QBIC("Quantitative Biology Center", "QBIC"),
-    CFMB_PCT("Proteomics Facility Tübingen", "Proteomics Facility")
+    CFMB_PCT("Proteomics Facility Tübingen", "Proteomics Facility"),
+    CEGAT("CeGaT GmbH", "CeGaT GmbH")
 
     private final String fullName
     private final String label

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/ExternalServiceProduct.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/ExternalServiceProduct.groovy
@@ -24,6 +24,7 @@ class ExternalServiceProduct extends PartialProduct {
      * @param serviceProvider The service provider
      */
     ExternalServiceProduct(String name, String description, double internalUnitPrice, double externalUnitPrice, ProductUnit unit, long runningNumber, Facility serviceProvider) {
-        super(name, description, internalUnitPrice, externalUnitPrice, unit, new ProductId.Builder(ProductType.EXTERNAL_SERVICE.toString(), runningNumber).build(), serviceProvider)
+       ProductId externalProductId = new ProductId.Builder(ProductType.EXTERNAL_SERVICE.toString(), runningNumber).build()
+        super(name, description, internalUnitPrice, externalUnitPrice, unit, externalProductId, serviceProvider)
     }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/ExternalServiceProduct.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/ExternalServiceProduct.groovy
@@ -1,0 +1,29 @@
+package life.qbic.datamodel.dtos.business.services
+
+import groovy.transform.EqualsAndHashCode
+import life.qbic.datamodel.dtos.business.ProductId
+import life.qbic.datamodel.dtos.business.facilities.Facility
+
+/**
+ * <p>External service product</p>
+ *
+ * <p>Represents a service product that is offered through QBiC by an external partner.</p>
+ *
+ * @since 2.13.0
+ */
+@EqualsAndHashCode(callSuper = true)
+class ExternalServiceProduct extends PartialProduct {
+    /**
+     * Creates an instance of an {@link ExternalServiceProduct}.
+     * @param name The name of the product
+     * @param description A product description
+     * @param internalUnitPrice The net internal unit price of the product
+     * @param externalUnitPrice The net external unit price of the product
+     * @param unit The unit of the product
+     * @param productId A product id, uniquely identifying the product in the offer environment
+     * @param serviceProvider The service provider
+     */
+    ExternalServiceProduct(String name, String description, double internalUnitPrice, double externalUnitPrice, ProductUnit unit, ProductId productId, Facility serviceProvider) {
+        super(name, description, internalUnitPrice, externalUnitPrice, unit, productId, serviceProvider)
+    }
+}

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/ExternalServiceProduct.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/ExternalServiceProduct.groovy
@@ -23,7 +23,7 @@ class ExternalServiceProduct extends PartialProduct {
      * @param productId A product id, uniquely identifying the product in the offer environment
      * @param serviceProvider The service provider
      */
-    ExternalServiceProduct(String name, String description, double internalUnitPrice, double externalUnitPrice, ProductUnit unit, ProductId productId, Facility serviceProvider) {
-        super(name, description, internalUnitPrice, externalUnitPrice, unit, productId, serviceProvider)
+    ExternalServiceProduct(String name, String description, double internalUnitPrice, double externalUnitPrice, ProductUnit unit, long runningNumber, Facility serviceProvider) {
+        super(name, description, internalUnitPrice, externalUnitPrice, unit, new ProductId.Builder(ProductType.EXTERNAL_SERVICE.toString(), runningNumber).build(), serviceProvider)
     }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/ExternalServiceProduct.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/ExternalServiceProduct.groovy
@@ -24,7 +24,6 @@ class ExternalServiceProduct extends PartialProduct {
      * @param serviceProvider The service provider
      */
     ExternalServiceProduct(String name, String description, double internalUnitPrice, double externalUnitPrice, ProductUnit unit, long runningNumber, Facility serviceProvider) {
-       ProductId externalProductId = new ProductId.Builder(ProductType.EXTERNAL_SERVICE.toString(), runningNumber).build()
-        super(name, description, internalUnitPrice, externalUnitPrice, unit, externalProductId, serviceProvider)
+        super(name, description, internalUnitPrice, externalUnitPrice, unit, new ProductId.Builder(ProductType.EXTERNAL_SERVICE.toString(), runningNumber).build(), serviceProvider)
     }
 }

--- a/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProductType.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/business/services/ProductType.groovy
@@ -15,7 +15,8 @@ enum ProductType {
     SECONDARY_BIOINFO("SB"),
     DATA_STORAGE("DS"),
     PROTEOMIC("PR"),
-    METABOLOMIC("ME")
+    METABOLOMIC("ME"),
+    EXTERNAL_SERVICE("EXT")
 
     /**
      Holds the String value of the enum


### PR DESCRIPTION
This PR adds a new product class ``ExternalServiceProduct`` to reflect external services in the QBiC service context.

Additionally, a first external facility enum has been added to the ``Facility`` enum.