### PR TITLE
Hotfix 2.14.2

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,6 +45,13 @@ jobs:
         java-version: 1.8
         settings-path: ${{ github.workspace }}
 
+    - name: Load local Maven repository cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,17 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+2.14.2 (2021-12-16)
+-------------------
+
+**Added**
+
+**Fixed**
+
+**Dependencies**
+
+**Deprecated**
+
 2.14.1 (2021-12-13)
 -------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Fixed**
 
+* CVE-2021-45046
+
 **Dependencies**
 
 * `org.codehaus.groovy:groovy-bom:2.5.10` -> `2.5.14`

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,17 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Dependencies**
 
+* `org.codehaus.groovy:groovy-bom:2.5.10` -> `2.5.14`
+* `org.codehaus.groovy:groovy-all:2.5.10` -> `2.5.14`
+* `org.osgi:osgi.core:7.0.0` -> 8.0.0
+* `com.github.everit-org.json-schema:org.everit.json.schema:1.12.1` -> `1.12.2`
+* `org.apache.logging.log4j:log4j-api:2.15.0` -> `2.16.0` (CVE-2021-45046)
+* `org.apache.logging.log4j:log4j-core:2.15.0` -> `2.16.0` (CVE-2021-45046)
+* `maven-surefire-plugin:2.21.0` -> `2.22.2`
+* `org.codehaus.gmavenplus:gmavenplus-plugin:1.12.0` -> `1.12.1`
+* `org.apache.maven.plugins:maven-site-plugin:3.7.1` -> `3.9.1`
+* `org.apache.maven.plugins:maven-project-info-reports-plugin:3.0.0` -> `3.1.1`
+
 **Deprecated**
 
 2.14.1 (2021-12-13)

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.2</version>
         <configuration>
           <includes>
             <include>**/*Spec</include>
@@ -181,7 +181,7 @@
       <plugin>
         <groupId>org.codehaus.gmavenplus</groupId>
         <artifactId>gmavenplus-plugin</artifactId>
-        <version>1.12.0</version>
+        <version>1.12.1</version>
         <executions>
           <execution>
             <goals>
@@ -217,12 +217,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.7.1</version>
+        <version>3.9.1</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.1</version>
       </plugin>
       <plugin>
         <groupId>life.qbic</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>life.qbic</groupId>
 	<artifactId>data-model-lib</artifactId>
-	<version>2.14.1</version> <!-- <<QUBE_FORCE_BUMP>> -->
+	<version>2.14.2</version> <!-- <<QUBE_FORCE_BUMP>> -->
 	<name>data-model-lib</name>
 	<url>http://github.com/qbicsoftware/data-model-lib</url>
 	<description>Data models. A collection of QBiC's central data models and DTOs. </description>

--- a/pom.xml
+++ b/pom.xml
@@ -1,241 +1,243 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project
-	xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
 
-    <groupId>life.qbic</groupId>
-	<artifactId>data-model-lib</artifactId>
-	<version>2.14.2</version> <!-- <<QUBE_FORCE_BUMP>> -->
-	<name>data-model-lib</name>
-	<url>http://github.com/qbicsoftware/data-model-lib</url>
-	<description>Data models. A collection of QBiC's central data models and DTOs. </description>
-	<packaging>jar</packaging>
+  <groupId>life.qbic</groupId>
+  <artifactId>data-model-lib</artifactId>
+  <version>2.14.2</version> <!-- <<QUBE_FORCE_BUMP>> -->
+  <name>data-model-lib</name>
+  <url>http://github.com/qbicsoftware/data-model-lib</url>
+  <description>Data models. A collection of QBiC's central data models and DTOs.</description>
+  <packaging>jar</packaging>
 
-    <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
 
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    </properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+  </properties>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>qbic-plugins-2</id>
-            <url>https://qbic-repo.qbic.uni-tuebingen.de/repository/maven-releases</url>
-        </pluginRepository>
-    </pluginRepositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>qbic-plugins-2</id>
+      <url>https://qbic-repo.qbic.uni-tuebingen.de/repository/maven-releases</url>
+    </pluginRepository>
+  </pluginRepositories>
 
-	<!-- we only need to tell maven where to find our parent pom and other QBiC dependencies -->
-	<repositories>
-		<repository>
-			<releases>
-				<enabled>true</enabled>
-				<updatePolicy>always</updatePolicy>
-				<checksumPolicy>fail</checksumPolicy>
-			</releases>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-			<id>maven-central</id>
-			<name>Maven central</name>
-			<url>https://repo.maven.apache.org/maven2</url>
-		</repository>
-		<repository>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-				<updatePolicy>always</updatePolicy>
-				<checksumPolicy>fail</checksumPolicy>
-			</snapshots>
-			<id>nexus-snapshots</id>
-			<name>QBiC Snapshots</name>
-			<url>https://qbic-repo.qbic.uni-tuebingen.de/repository/maven-snapshots</url>
-		</repository>
-		<repository>
-			<releases>
-				<enabled>true</enabled>
-				<updatePolicy>always</updatePolicy>
-				<checksumPolicy>fail</checksumPolicy>
-			</releases>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-			<id>nexus-releases</id>
-			<name>QBiC Releases</name>
-			<url>https://qbic-repo.qbic.uni-tuebingen.de/repository/maven-releases</url>
-		</repository>
-        <!-- Host the everit json schema dependency -->
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
-	</repositories>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.codehaus.groovy</groupId>
-                <artifactId>groovy-bom</artifactId>
-                <version>2.5.10</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-          <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <version>2.5.10</version>
-            <type>pom</type>
-            <scope>${osgi.scope}</scope>
-          </dependency>
-        </dependencies>
-    </dependencyManagement>
+  <!-- we only need to tell maven where to find our parent pom and other QBiC dependencies -->
+  <repositories>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>maven-central</id>
+      <name>Maven central</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+    </repository>
+    <repository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+      <id>nexus-snapshots</id>
+      <name>QBiC Snapshots</name>
+      <url>https://qbic-repo.qbic.uni-tuebingen.de/repository/maven-snapshots</url>
+    </repository>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>nexus-releases</id>
+      <name>QBiC Releases</name>
+      <url>https://qbic-repo.qbic.uni-tuebingen.de/repository/maven-releases</url>
+    </repository>
+    <!-- Host the everit json schema dependency -->
+    <repository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
+    </repository>
+  </repositories>
+  <dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <version>7.0.0</version>
-            <scope>${osgi.scope}</scope>
-        </dependency>
-        <!-- JSON schema validator -->
-        <dependency>
-            <groupId>com.github.everit-org.json-schema</groupId>
-            <artifactId>org.everit.json.schema</artifactId>
-            <version>1.12.1</version>
-          <scope>${osgi.scope}</scope>
-        </dependency>
       <dependency>
-        <groupId>life.qbic</groupId>
-        <artifactId>xml-manager-lib</artifactId>
-        <version>1.6.0</version>
-        <scope>${osgi.scope}</scope>
+        <groupId>org.codehaus.groovy</groupId>
+        <artifactId>groovy-bom</artifactId>
+        <version>2.5.10</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
-      		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>2.15.0</version>
-			<scope>${osgi.scope}</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>2.15.0</version>
-			<scope>${osgi.scope}</scope>
-		</dependency>
-      <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations -->
       <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>2.13.0</version>
+        <groupId>org.codehaus.groovy</groupId>
+        <artifactId>groovy-all</artifactId>
+        <version>2.5.10</version>
+        <type>pom</type>
         <scope>${osgi.scope}</scope>
-      </dependency>
-      <!-- https://mvnrepository.com/artifact/javax.validation/validation-api -->
-      <dependency>
-        <groupId>javax.validation</groupId>
-        <artifactId>validation-api</artifactId>
-        <version>2.0.1.Final</version>
-        <scope>${osgi.scope}</scope>
-      </dependency>
-      <!-- Spock testing framework -->
-      <dependency>
-          <groupId>org.spockframework</groupId>
-          <artifactId>spock-core</artifactId>
-          <version>2.0-groovy-2.5</version>
-          <scope>test</scope>
       </dependency>
     </dependencies>
-     <distributionManagement>
-      <repository>
-        <uniqueVersion>true</uniqueVersion>
-        <id>nexus-releases</id>
-        <name>QBiC Releases</name>
-        <url>https://qbic-repo.qbic.uni-tuebingen.de/repository/maven-releases</url>
-      </repository>
-      <snapshotRepository>
-        <uniqueVersion>false</uniqueVersion>
-        <id>nexus-snapshots</id>
-        <name>QBiC Snapshots</name>
-        <url>https://qbic-repo.qbic.uni-tuebingen.de/repository/maven-snapshots</url>
-      </snapshotRepository>
-    </distributionManagement>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-            </plugin>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <version>2.21.0</version>
-            <configuration>
-              <includes>
-                <include>**/*Spec</include>
-              </includes>
-            </configuration>
-          </plugin>
-            <plugin>
-                <groupId>org.codehaus.gmavenplus</groupId>
-                <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.12.0</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>execute</goal>
-                            <goal>addSources</goal>
-                            <goal>addTestSources</goal>
-                            <goal>generateStubs</goal>
-                            <goal>compile</goal>
-                            <goal>generateTestStubs</goal>
-                            <goal>compileTests</goal>
-                            <goal>removeStubs</goal>
-                            <goal>removeTestStubs</goal>
-                        </goals>
-                    </execution>
-                  <execution>
-                    <id>site</id>
-                    <phase>site</phase>
-                    <goals>
-                      <goal>generateStubs</goal>
-                      <goal>generateTestStubs</goal>
-                      <goal>groovydoc</goal>
-                      <goal>groovydocTests</goal>
-                    </goals>
-                  </execution>
-                </executions>
-              <configuration>
-                <groovyDocOutputDirectory>${project.build.directory}/site/gapidocs</groovyDocOutputDirectory>
-                <testGroovyDocOutputDirectory>${project.build.directory}/site/testgapidocs</testGroovyDocOutputDirectory>
-              </configuration>
-            </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-site-plugin</artifactId>
-            <version>3.7.1</version>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-project-info-reports-plugin</artifactId>
-            <version>3.0.0</version>
-          </plugin>
-          <plugin>
-            <groupId>life.qbic</groupId>
-            <artifactId>groovydoc-maven-plugin</artifactId>
-            <version>1.0.2</version>
-          </plugin>
-        </plugins>
-    </build>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>osgi.core</artifactId>
+      <version>7.0.0</version>
+      <scope>${osgi.scope}</scope>
+    </dependency>
+    <!-- JSON schema validator -->
+    <dependency>
+      <groupId>com.github.everit-org.json-schema</groupId>
+      <artifactId>org.everit.json.schema</artifactId>
+      <version>1.12.1</version>
+      <scope>${osgi.scope}</scope>
+    </dependency>
+    <dependency>
+      <groupId>life.qbic</groupId>
+      <artifactId>xml-manager-lib</artifactId>
+      <version>1.6.0</version>
+      <scope>${osgi.scope}</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.15.0</version>
+      <scope>${osgi.scope}</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.15.0</version>
+      <scope>${osgi.scope}</scope>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.13.0</version>
+      <scope>${osgi.scope}</scope>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/javax.validation/validation-api -->
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+      <version>2.0.1.Final</version>
+      <scope>${osgi.scope}</scope>
+    </dependency>
+    <!-- Spock testing framework -->
+    <dependency>
+      <groupId>org.spockframework</groupId>
+      <artifactId>spock-core</artifactId>
+      <version>2.0-groovy-2.5</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <distributionManagement>
+    <repository>
+      <uniqueVersion>true</uniqueVersion>
+      <id>nexus-releases</id>
+      <name>QBiC Releases</name>
+      <url>https://qbic-repo.qbic.uni-tuebingen.de/repository/maven-releases</url>
+    </repository>
+    <snapshotRepository>
+      <uniqueVersion>false</uniqueVersion>
+      <id>nexus-snapshots</id>
+      <name>QBiC Snapshots</name>
+      <url>https://qbic-repo.qbic.uni-tuebingen.de/repository/maven-snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.21.0</version>
+        <configuration>
+          <includes>
+            <include>**/*Spec</include>
+          </includes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <version>1.12.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>execute</goal>
+              <goal>addSources</goal>
+              <goal>addTestSources</goal>
+              <goal>generateStubs</goal>
+              <goal>compile</goal>
+              <goal>generateTestStubs</goal>
+              <goal>compileTests</goal>
+              <goal>removeStubs</goal>
+              <goal>removeTestStubs</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>site</id>
+            <phase>site</phase>
+            <goals>
+              <goal>generateStubs</goal>
+              <goal>generateTestStubs</goal>
+              <goal>groovydoc</goal>
+              <goal>groovydocTests</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <groovyDocOutputDirectory>${project.build.directory}/site/gapidocs
+          </groovyDocOutputDirectory>
+          <testGroovyDocOutputDirectory>${project.build.directory}/site/testgapidocs
+          </testGroovyDocOutputDirectory>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>3.7.1</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>3.0.0</version>
+      </plugin>
+      <plugin>
+        <groupId>life.qbic</groupId>
+        <artifactId>groovydoc-maven-plugin</artifactId>
+        <version>1.0.2</version>
+      </plugin>
+    </plugins>
+  </build>
   <reporting>
     <plugins>
-    <plugin>
-    <groupId>life.qbic</groupId>
-    <artifactId>groovydoc-maven-plugin</artifactId>
-  </plugin>
-  </plugins>
-</reporting>
+      <plugin>
+        <groupId>life.qbic</groupId>
+        <artifactId>groovydoc-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </reporting>
   <profiles>
     <profile>
       <id>no-liferay</id>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <log4j.version>2.16.0</log4j.version>
   </properties>
 
   <pluginRepositories>
@@ -80,14 +81,14 @@
       <dependency>
         <groupId>org.codehaus.groovy</groupId>
         <artifactId>groovy-bom</artifactId>
-        <version>2.5.10</version>
+        <version>2.5.14</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.codehaus.groovy</groupId>
         <artifactId>groovy-all</artifactId>
-        <version>2.5.10</version>
+        <version>2.5.14</version>
         <type>pom</type>
         <scope>${osgi.scope}</scope>
       </dependency>
@@ -97,14 +98,14 @@
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>osgi.core</artifactId>
-      <version>7.0.0</version>
+      <version>8.0.0</version>
       <scope>${osgi.scope}</scope>
     </dependency>
     <!-- JSON schema validator -->
     <dependency>
       <groupId>com.github.everit-org.json-schema</groupId>
       <artifactId>org.everit.json.schema</artifactId>
-      <version>1.12.1</version>
+      <version>1.12.2</version>
       <scope>${osgi.scope}</scope>
     </dependency>
     <dependency>
@@ -116,13 +117,13 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.15.0</version>
+      <version>${log4j.version}</version>
       <scope>${osgi.scope}</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.15.0</version>
+      <version>${log4j.version}</version>
       <scope>${osgi.scope}</scope>
     </dependency>
     <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations -->


### PR DESCRIPTION
2.14.2 (2021-12-16)
-------------------

**Added**

**Fixed**

**Dependencies**

* `org.codehaus.groovy:groovy-bom:2.5.10` -> `2.5.14`
* `org.codehaus.groovy:groovy-all:2.5.10` -> `2.5.14`
* `org.osgi:osgi.core:7.0.0` -> 8.0.0
* `com.github.everit-org.json-schema:org.everit.json.schema:1.12.1` -> `1.12.2`
* `org.apache.logging.log4j:log4j-api:2.15.0` -> `2.16.0` (CVE-2021-45046)
* `org.apache.logging.log4j:log4j-core:2.15.0` -> `2.16.0` (CVE-2021-45046)
* `maven-surefire-plugin:2.21.0` -> `2.22.2`
* `org.codehaus.gmavenplus:gmavenplus-plugin:1.12.0` -> `1.12.1`
* `org.apache.maven.plugins:maven-site-plugin:3.7.1` -> `3.9.1`
* `org.apache.maven.plugins:maven-project-info-reports-plugin:3.0.0` -> `3.1.1`

**Deprecated**