### PR TITLE
Hotfix 2.14.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,23 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+2.14.4 (2022-01-04)
+-------------------
+
+**Added**
+
+**Fixed**
+
+* CVE-2021-44832
+
+**Dependencies**
+
+* Bump `org.apache.logging.log4j:log4j-api` from 2.17.0 to 2.17.1
+
+* Bump `org.apache.logging.log4j:log4j-core` from 2.17.0 to 2.17.1
+
+**Deprecated**
+
 2.14.3 (2021-12-20)
 -------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>life.qbic</groupId>
   <artifactId>data-model-lib</artifactId>
-  <version>2.14.3</version> <!-- <<QUBE_FORCE_BUMP>> -->
+  <version>2.14.4</version> <!-- <<QUBE_FORCE_BUMP>> -->
   <name>data-model-lib</name>
   <url>http://github.com/qbicsoftware/data-model-lib</url>
   <description>Data models. A collection of QBiC's central data models and DTOs.</description>
@@ -19,7 +19,7 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <log4j.version>2.17.0</log4j.version>
+    <log4j.version>2.17.1</log4j.version>
   </properties>
 
   <pluginRepositories>


### PR DESCRIPTION
2.14.4 (2022-01-04)
-------------------

**Added**

**Fixed**

* CVE-2021-44832

**Dependencies**

* Bump `org.apache.logging.log4j:log4j-api` from 2.17.0 to 2.17.1

* Bump `org.apache.logging.log4j:log4j-core` from 2.17.0 to 2.17.1

**Deprecated**