### PR TITLE
Remove everit-json from compile scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
       <groupId>com.github.everit-org.json-schema</groupId>
       <artifactId>org.everit.json.schema</artifactId>
       <version>1.12.2</version>
-      <scope>${osgi.scope}</scope>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>life.qbic</groupId>

--- a/src/main/groovy/life/qbic/datamodel/datasets/OxfordNanoporeMeasurement.groovy
+++ b/src/main/groovy/life/qbic/datamodel/datasets/OxfordNanoporeMeasurement.groovy
@@ -66,7 +66,6 @@ final class OxfordNanoporeMeasurement {
 
     private static void validateMetaData(Map metadata) throws IllegalArgumentException {
         def expectedKeys = [
-                "adapter",
                 "asic_temp",
                 "base_caller",
                 "base_caller_version",

--- a/src/main/groovy/life/qbic/datamodel/datasets/OxfordNanoporeMeasurement.groovy
+++ b/src/main/groovy/life/qbic/datamodel/datasets/OxfordNanoporeMeasurement.groovy
@@ -67,8 +67,8 @@ final class OxfordNanoporeMeasurement {
 
     private static void validateMetaData(Map metadata) throws IllegalArgumentException {
 
-        InputStream stream = Thread.currentThread().getContextClassLoader().getResourceAsStream("schemas/ont-metadata.schema.json")
-        Map schema = (Map) new JsonSlurper().parse(stream)
+        InputStream stream = this.getClassLoader().getResourceAsStream("schemas/ont-metadata.schema.json")
+        def schema = new JsonSlurper().parse(stream) as Map<String, ?>
 
         def expectedKeys = schema.get("required") as List<String>
 

--- a/src/main/groovy/life/qbic/datamodel/datasets/OxfordNanoporeMeasurement.groovy
+++ b/src/main/groovy/life/qbic/datamodel/datasets/OxfordNanoporeMeasurement.groovy
@@ -1,5 +1,6 @@
 package life.qbic.datamodel.datasets
 
+import groovy.json.JsonSlurper
 import groovy.util.logging.Log4j2
 import life.qbic.datamodel.datasets.datastructure.files.DataFile
 import life.qbic.datamodel.datasets.datastructure.folders.DataFolder
@@ -65,18 +66,12 @@ final class OxfordNanoporeMeasurement {
     }
 
     private static void validateMetaData(Map metadata) throws IllegalArgumentException {
-        def expectedKeys = [
-                "asic_temp",
-                "base_caller",
-                "base_caller_version",
-                "device_type",
-                "flow_cell_id",
-                "flow_cell_position",
-                "flow_cell_product_code",
-                "protocol",
-                "hostname",
-                "started"
-        ]
+
+        InputStream stream = Thread.currentThread().getContextClassLoader().getResourceAsStream("schemas/ont-metadata.schema.json")
+        Map schema = (Map) new JsonSlurper().parse(stream)
+
+        def expectedKeys = schema.get("required") as List<String>
+
         def missingKeys = expectedKeys.stream()
                 .filter({ !metadata.keySet().contains(it) })
                 .collect()

--- a/src/main/groovy/life/qbic/datamodel/datasets/OxfordNanoporeMeasurement.groovy
+++ b/src/main/groovy/life/qbic/datamodel/datasets/OxfordNanoporeMeasurement.groovy
@@ -1,17 +1,12 @@
 package life.qbic.datamodel.datasets
 
+import groovy.util.logging.Log4j2
 import life.qbic.datamodel.datasets.datastructure.files.DataFile
 import life.qbic.datamodel.datasets.datastructure.folders.DataFolder
 import life.qbic.datamodel.datasets.datastructure.folders.nanopore.*
-import org.everit.json.schema.ValidationException
 
 import java.util.regex.Matcher
 import java.util.regex.Pattern
-
-import org.everit.json.schema.loader.SchemaLoader
-import org.json.JSONObject
-import org.json.JSONTokener
-import groovy.util.logging.Log4j2
 
 /**
  * A dataset that represents a Oxford Nanopore Measurement.
@@ -70,12 +65,24 @@ final class OxfordNanoporeMeasurement {
     }
 
     private static void validateMetaData(Map metadata) throws IllegalArgumentException {
-        try {
-            MetaData.validateMetadata(metadata)
-        } catch (ValidationException e) {
-            // Aggregate the causing exceptions
-            def causes = e.getAllMessages().join("\n")
-            throw new IllegalArgumentException("The Nanopore metadata could not be collected.\nReason:\n$causes",)
+        def expectedKeys = [
+                "adapter",
+                "asic_temp",
+                "base_caller",
+                "base_caller_version",
+                "device_type",
+                "flow_cell_id",
+                "flow_cell_position",
+                "flow_cell_product_code",
+                "protocol",
+                "hostname",
+                "started"
+        ]
+        def missingKeys = expectedKeys.stream()
+                .filter({ !metadata.keySet().contains(it) })
+                .collect()
+        if (!missingKeys.isEmpty()) {
+            throw new IllegalArgumentException('Required metadata properties missing: ' + missingKeys.join(", "))
         }
     }
 
@@ -368,25 +375,4 @@ final class OxfordNanoporeMeasurement {
     String getRelativePath() {
         return this.measurementFolder.relativePath
     }
-
-    /*
-    Inner class that contains the logic for the metadata validation
-     */
-    private static class MetaData {
-
-        private static final SCHEMA = "/schemas/ont-metadata.schema.json"
-
-        static validateMetadata(Map metaData) throws ValidationException {
-            // Load schema
-            final def metaDataJson = new JSONObject(metaData)
-            final def schemaStream = OxfordNanoporeMeasurement.getResourceAsStream(SCHEMA)
-            final def rawSchema = new JSONObject(new JSONTokener(schemaStream))
-            final def jsonSchema = SchemaLoader.load(rawSchema)
-            // Validate against schema
-            jsonSchema.validate(metaDataJson)
-        }
-
-    }
-
-
 }

--- a/src/main/groovy/life/qbic/datamodel/datasets/OxfordNanoporeMeasurement.groovy
+++ b/src/main/groovy/life/qbic/datamodel/datasets/OxfordNanoporeMeasurement.groovy
@@ -17,23 +17,8 @@ import java.util.regex.Pattern
 @Log4j2
 final class OxfordNanoporeMeasurement {
 
-    private static final String LIBRARY_PREP_KIT_SCHEMA = "SQK-.*(?=:)"
 
-    private static final enum METADATA_FIELD {
-        ADAPTER,
-        ASIC_TEMP,
-        BASE_CALLER,
-        BASE_CALLER_VERSION,
-        DEVICE_TYPE,
-        FLOWCELL_ID,
-        FLOWCELL_POSITION,
-        FLOWCELL_TYPE,
-        LIBRARY_PREPARATION_KIT,
-        MACHINE_HOST,
-        START_DATE
-    }
-
-    private final Map<METADATA_FIELD, String> metadata
+    private final Metadata metadata
 
     private final Map<String, DataFolder> folders
 
@@ -46,12 +31,11 @@ final class OxfordNanoporeMeasurement {
     protected OxfordNanoporeMeasurement(String name, String path, List children, Map metadata) {
         this.logFilesCollection = new ArrayList<>()
         this.folders = new HashMap<>()
-        this.metadata = new HashMap()
 
         this.measurementFolder = MeasurementFolder.create(name, path, children)
 
-        validateMetaData(metadata)
-        readMetaData(metadata)
+        this.metadata = Metadata.from(metadata)
+
         createContent()
         assessPooledStatus()
         assessState()
@@ -63,21 +47,6 @@ final class OxfordNanoporeMeasurement {
 
     static OxfordNanoporeMeasurement create(String name, String path, List children, Map metadata) {
         return new OxfordNanoporeMeasurement(name, path, children, metadata)
-    }
-
-    private static void validateMetaData(Map metadata) throws IllegalArgumentException {
-
-        InputStream stream = this.getClassLoader().getResourceAsStream("schemas/ont-metadata.schema.json")
-        def schema = new JsonSlurper().parse(stream) as Map<String, ?>
-
-        def expectedKeys = schema.get("required") as List<String>
-
-        def missingKeys = expectedKeys.stream()
-                .filter({ !metadata.keySet().contains(it) })
-                .collect()
-        if (!missingKeys.isEmpty()) {
-            throw new IllegalArgumentException('Required metadata properties missing: ' + missingKeys.join(", "))
-        }
     }
 
     private void assessPooledStatus() {
@@ -96,33 +65,6 @@ final class OxfordNanoporeMeasurement {
             return folder.getChildren().any { it instanceof Fast5Folder }
         }
         return false
-    }
-
-    private void readMetaData(Map<String, String> metadata) {
-        this.metadata[METADATA_FIELD.ADAPTER] = metadata["adapter"]
-        this.metadata[METADATA_FIELD.ASIC_TEMP] = metadata["asic_temp"]
-        this.metadata[METADATA_FIELD.BASE_CALLER] = metadata["base_caller"]
-        this.metadata[METADATA_FIELD.BASE_CALLER_VERSION] = metadata["base_caller_version"]
-        this.metadata[METADATA_FIELD.DEVICE_TYPE] = metadata["device_type"]
-        this.metadata[METADATA_FIELD.FLOWCELL_ID] = metadata["flow_cell_id"]
-        this.metadata[METADATA_FIELD.FLOWCELL_POSITION] = metadata["flow_cell_position"]
-        this.metadata[METADATA_FIELD.FLOWCELL_TYPE] = metadata["flow_cell_product_code"]
-        this.metadata[METADATA_FIELD.LIBRARY_PREPARATION_KIT] = extractLibraryKit(metadata["protocol"] ?: "")
-        this.metadata[METADATA_FIELD.MACHINE_HOST] = metadata["hostname"]
-        this.metadata[METADATA_FIELD.START_DATE] = metadata["started"]
-    }
-
-    private static String extractLibraryKit(String text) {
-        Set<String> result = []
-        Pattern pattern = Pattern.compile(LIBRARY_PREP_KIT_SCHEMA, Pattern.CASE_INSENSITIVE)
-        Matcher m = pattern.matcher(text)
-        while (m.find()) {
-            result.add(m.group())
-        }
-        if (result.isEmpty()) {
-            throw new MissingPropertyException("Could not find information about the library preparation kit.")
-        }
-        return result[0]
     }
 
     private void createContent() {
@@ -216,7 +158,7 @@ final class OxfordNanoporeMeasurement {
      * @return
      */
     String getAdapter() {
-        return metadata.get(METADATA_FIELD.ADAPTER) ?: ""
+        return metadata.getAdapter()
     }
 
     /**
@@ -224,7 +166,7 @@ final class OxfordNanoporeMeasurement {
      * @return
      */
     String getAsicTemp() {
-        return metadata.get(METADATA_FIELD.ASIC_TEMP)
+        return metadata.getAsicTemp()
     }
 
     /**
@@ -232,7 +174,7 @@ final class OxfordNanoporeMeasurement {
      * @return
      */
     String getDeviceType() {
-        return metadata.get(METADATA_FIELD.DEVICE_TYPE)
+        return metadata.getDeviceType()
     }
 
     /**
@@ -240,7 +182,7 @@ final class OxfordNanoporeMeasurement {
      * @return
      */
     String getFlowcellId() {
-        return metadata.get(METADATA_FIELD.FLOWCELL_ID)
+        return metadata.getFlowcellId()
     }
 
     /**
@@ -248,7 +190,7 @@ final class OxfordNanoporeMeasurement {
      * @return
      */
     String getFlowCellPosition() {
-        return metadata.get(METADATA_FIELD.FLOWCELL_POSITION)
+        return metadata.getFlowcellPosition()
     }
 
     /**
@@ -256,7 +198,7 @@ final class OxfordNanoporeMeasurement {
      * @return
      */
     String getFlowCellType() {
-        return metadata.get(METADATA_FIELD.FLOWCELL_TYPE)
+        return metadata.getFlowcellType()
     }
 
     /**
@@ -264,7 +206,7 @@ final class OxfordNanoporeMeasurement {
      * @return
      */
     String getBaseCaller() {
-        return metadata.get(METADATA_FIELD.BASE_CALLER)
+        return metadata.getBaseCaller()
     }
 
     /**
@@ -272,7 +214,7 @@ final class OxfordNanoporeMeasurement {
      * @return
      */
     String getBaseCallerVersion() {
-        return metadata.get(METADATA_FIELD.BASE_CALLER_VERSION)
+        return metadata.getBaseCallerVersion()
     }
 
     /**
@@ -280,7 +222,7 @@ final class OxfordNanoporeMeasurement {
      * @return
      */
     String getLibraryPreparationKit() {
-        return metadata.get(METADATA_FIELD.LIBRARY_PREPARATION_KIT)
+        metadata.getLibraryPreparationKit()
     }
 
     /**
@@ -288,7 +230,7 @@ final class OxfordNanoporeMeasurement {
      * @return
      */
     String getMachineHost() {
-        return metadata.get(METADATA_FIELD.MACHINE_HOST)
+        metadata.getMachineHost()
     }
 
     /**
@@ -296,7 +238,7 @@ final class OxfordNanoporeMeasurement {
      * @return
      */
     String getStartDate() {
-        return metadata.get(METADATA_FIELD.START_DATE)
+        metadata.getStartDate()
     }
 
     private Map<String, DataFolder> prepareUnclassifiedData() {
@@ -368,5 +310,124 @@ final class OxfordNanoporeMeasurement {
      */
     String getRelativePath() {
         return this.measurementFolder.relativePath
+    }
+
+    private static class Metadata {
+        private static final Map<String, ?> SCHEMA = parseMetadataSchema()
+        private static final String LIBRARY_PREP_KIT_SCHEMA = "SQK-.*(?=:)"
+
+        private String adapter
+        private String asicTemp
+        private String deviceType
+        private String flowcellId
+        private String flowcellPosition
+        private String flowcellType
+        private String baseCaller
+        private String baseCallerVersion
+        private String libraryPreparationKit
+        private String machineHost
+        private String startDate
+
+        private Metadata() {}
+
+        /**
+         * Reads metadata information from the provided map given the map is valid according to the schema.
+         *
+         * @param metadataMap a map containing all required metadata
+         * @return a valid Metadata instance containing relevant information from the map
+         */
+        static Metadata from(Map<String, ?> metadataMap) {
+            validateMetaDataMap(metadataMap)
+            Metadata metadata = new Metadata()
+            metadata.readMetaData(metadataMap)
+            return metadata
+        }
+
+        private static Map<String, ?> parseMetadataSchema() {
+            URL schemaUrl = this.getClassLoader().getResource("schemas/ont-metadata.schema.json")
+            return new JsonSlurper().parse(schemaUrl) as Map<String, ?>
+        }
+
+        private static void validateMetaDataMap(Map metadata) throws IllegalArgumentException {
+            def expectedKeys = SCHEMA.get("required") as List<String>
+
+            def missingKeys = expectedKeys.stream()
+                    .filter({ !metadata.keySet().contains(it) })
+                    .collect()
+            if (!missingKeys.isEmpty()) {
+                throw new IllegalArgumentException('Required metadata properties missing: ' + missingKeys.join(", "))
+            }
+        }
+
+        private static String extractLibraryKit(String text) {
+            Set<String> result = []
+            Pattern pattern = Pattern.compile(LIBRARY_PREP_KIT_SCHEMA, Pattern.CASE_INSENSITIVE)
+            Matcher m = pattern.matcher(text)
+            while (m.find()) {
+                result.add(m.group())
+            }
+            if (result.isEmpty()) {
+                throw new MissingPropertyException("Could not find information about the library preparation kit.")
+            }
+            return result[0]
+        }
+
+        private void readMetaData(Map<String, String> metadata) {
+            this.adapter = metadata["adapter"] ?: ""
+            this.asicTemp = metadata["asic_temp"]
+            this.baseCaller = metadata["base_caller"]
+            this.baseCallerVersion = metadata["base_caller_version"]
+            this.deviceType = metadata["device_type"]
+            this.flowcellId = metadata["flow_cell_id"]
+            this.flowcellPosition = metadata["flow_cell_position"]
+            this.flowcellType = metadata["flow_cell_product_code"]
+            this.libraryPreparationKit = extractLibraryKit(metadata["protocol"] ?: "")
+            this.machineHost = metadata["hostname"]
+            this.startDate = metadata["started"]
+        }
+
+        String getAdapter() {
+            return adapter
+        }
+
+        String getAsicTemp() {
+            return asicTemp
+        }
+
+        String getDeviceType() {
+            return deviceType
+        }
+
+        String getFlowcellId() {
+            return flowcellId
+        }
+
+        String getFlowcellPosition() {
+            return flowcellPosition
+        }
+
+        String getFlowcellType() {
+            return flowcellType
+        }
+
+        String getBaseCaller() {
+            return baseCaller
+        }
+
+        String getBaseCallerVersion() {
+            return baseCallerVersion
+        }
+
+        String getLibraryPreparationKit() {
+            return libraryPreparationKit
+        }
+
+        String getMachineHost() {
+            return machineHost
+        }
+
+        String getStartDate() {
+            return startDate
+        }
     }
 }


### PR DESCRIPTION
Removes everit.json from compile scope so that the `jitpack` repository does not need to be imported by users of this lib.
```
<groupId>com.github.everit-org.json-schema</groupId>
<artifactId>org.everit.json.schema</artifactId>
```
Further, this PR simplifies metadata format validation and removes the specification for it in form of a JSON schema (as it is straightforward and property names are hardcoded anyhow). Validation is still checked in the test specifications.
