### PR TITLE
Remove automatic replacement of hyphens with underscores in Project Space naming

### DIFF
--- a/src/main/groovy/life/qbic/datamodel/dtos/projectmanagement/ProjectSpace.groovy
+++ b/src/main/groovy/life/qbic/datamodel/dtos/projectmanagement/ProjectSpace.groovy
@@ -44,7 +44,6 @@ final class ProjectSpace {
     private static String formatSpaceName(String name) {
         def capitalizedName = name.trim().toUpperCase()
         def refactoredName = capitalizedName.replaceAll("\\s+", "_")
-                .replaceAll("-", "_")
         return refactoredName
     }
 

--- a/src/test/groovy/life/qbic/datamodel/dtos/projectmanagement/ProjectSpaceSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/dtos/projectmanagement/ProjectSpaceSpec.groovy
@@ -31,15 +31,4 @@ class ProjectSpaceSpec extends Specification {
         thrown(IllegalArgumentException)
 
     }
-
-    def "Dashes are replaced by underscores"() {
-        given:
-        String projectSpaceName = "my-new-space"
-
-        when:
-        ProjectSpace space = new ProjectSpace(projectSpaceName)
-
-        then:
-        space.name.equals("MY_NEW_SPACE")
-    }
 }


### PR DESCRIPTION
**What was changed** 
This PR allows project spaces with hyphens in their name by removing their automatic replacement with underscores in the project space class 

**Additional Information** 
See [DM-481](https://qbicsoftware.atlassian.net/jira/software/c/projects/DM/boards/4?modal=detail&selectedIssue=DM-481) for more information 