### PR TITLE
Introduce minimal Schema for nanopore registration 

### DIFF
--- a/src/main/groovy/life/qbic/datamodel/datasets/OxfordNanoporeExperiment.groovy
+++ b/src/main/groovy/life/qbic/datamodel/datasets/OxfordNanoporeExperiment.groovy
@@ -1,7 +1,9 @@
 package life.qbic.datamodel.datasets
 
 import life.qbic.datamodel.datasets.datastructure.files.DataFile
+import life.qbic.datamodel.datasets.datastructure.files.nanopore.OptionalFile
 import life.qbic.datamodel.datasets.datastructure.folders.DataFolder
+import life.qbic.datamodel.datasets.datastructure.folders.nanopore.OptionalFolder
 import life.qbic.datamodel.identifiers.SampleCodeFunctions
 
 import java.lang.reflect.InvocationTargetException
@@ -14,239 +16,258 @@ import java.lang.reflect.Method
  */
 final class OxfordNanoporeExperiment implements ExperimentFolder {
 
-    // Fully qualified domain name of the nanopore folder structure package
-    private final static String FQDN_FOLDERS = "life.qbic.datamodel.datasets.datastructure.folders.nanopore"
-    // Fully qualified domain name of the nanopore file structure package
-    private final static String FQDN_FILES = "life.qbic.datamodel.datasets.datastructure.files.nanopore"
+  // Fully qualified domain name of the nanopore folder structure package
+  private final static String FQDN_FOLDERS = "life.qbic.datamodel.datasets.datastructure.folders.nanopore"
+  // Fully qualified domain name of the nanopore file structure package
+  private final static String FQDN_FILES = "life.qbic.datamodel.datasets.datastructure.files.nanopore"
 
-    private final List<OxfordNanoporeMeasurement> measurements
+  //Unique key in fileTreeMap identifying a child as a file
+  private final static String FILEKEY = "file_type"
+  //Unique key in fileTreeMap identifyng a child as a folder
+  private final static String FOLDERKEY = "children"
 
-    private final String sampleId
+  private final List<OxfordNanoporeMeasurement> measurements
 
-    private final static Set nanoporeFileTypes = [
-            FQDN_FILES + ".DriftCorrectionLog",
-            FQDN_FILES + ".DutyTimeLog",
-            FQDN_FILES + ".Fast5File",
-            FQDN_FILES + ".FastQFile",
-            FQDN_FILES + ".FastQZippedFile",
-            FQDN_FILES + ".FinalSummaryLog",
-            FQDN_FILES + ".MuxScanDataLog",
-            FQDN_FILES + ".ReportMdLog",
-            FQDN_FILES + ".ReportPDFLog",
-            FQDN_FILES + ".ReportHTMLLog",
-            FQDN_FILES + ".ReportJSONLog",
-            FQDN_FILES + ".SequencingSummaryLog",
-            FQDN_FILES + ".ThroughputLog",
-            FQDN_FILES + ".BarcodeAlignmentLog",
-            FQDN_FILES + ".PoreActivityLog",
-            FQDN_FILES + ".SampleSheetLog",
-            FQDN_FILES + ".PoreScanDataLog",
-            FQDN_FILES + ".SequencingTelemetryLog",
-            FQDN_FILES + ".GuppyBasecallLog"
-    ]
+  private final String sampleId
 
-    private final static Set nanoporeFolderTypes = [
-            FQDN_FOLDERS + ".Fast5Folder",
-            FQDN_FOLDERS + ".FastQFolder",
-            FQDN_FOLDERS + ".Fast5PassFolder",
-            FQDN_FOLDERS + ".Fast5FailFolder",
-            FQDN_FOLDERS + ".FastQPassFolder",
-            FQDN_FOLDERS + ".FastQFailFolder",
-            FQDN_FOLDERS + ".UnclassifiedFast5Folder",
-            FQDN_FOLDERS + ".UnclassifiedFastQFolder",
-            FQDN_FOLDERS + ".OtherReportsFolder",
-            FQDN_FOLDERS + ".BasecallingFolder"
-    ]
+  private final static Set nanoporeFileTypes = [
+          FQDN_FILES + ".DriftCorrectionLog",
+          FQDN_FILES + ".DutyTimeLog",
+          FQDN_FILES + ".Fast5File",
+          FQDN_FILES + ".FastQFile",
+          FQDN_FILES + ".FastQZippedFile",
+          FQDN_FILES + ".FinalSummaryLog",
+          FQDN_FILES + ".MuxScanDataLog",
+          FQDN_FILES + ".ReportMdLog",
+          FQDN_FILES + ".ReportPDFLog",
+          FQDN_FILES + ".ReportHTMLLog",
+          FQDN_FILES + ".ReportJSONLog",
+          FQDN_FILES + ".SequencingSummaryLog",
+          FQDN_FILES + ".ThroughputLog",
+          FQDN_FILES + ".BarcodeAlignmentLog",
+          FQDN_FILES + ".PoreActivityLog",
+          FQDN_FILES + ".SampleSheetLog",
+          FQDN_FILES + ".PoreScanDataLog",
+          FQDN_FILES + ".SequencingTelemetryLog",
+          FQDN_FILES + ".GuppyBasecallLog"
+  ]
 
-    private OxfordNanoporeExperiment(String sampleId, List<OxfordNanoporeMeasurement> measurements) {
-        this.measurements = Objects.requireNonNull(measurements, "measurements must not be null")
-        this.sampleId = Objects.requireNonNull(sampleId, "sampleId must not be null")
+  private final static Set nanoporeFolderTypes = [
+          FQDN_FOLDERS + ".Fast5Folder",
+          FQDN_FOLDERS + ".FastQFolder",
+          FQDN_FOLDERS + ".Fast5PassFolder",
+          FQDN_FOLDERS + ".Fast5FailFolder",
+          FQDN_FOLDERS + ".FastQPassFolder",
+          FQDN_FOLDERS + ".FastQFailFolder",
+          FQDN_FOLDERS + ".UnclassifiedFast5Folder",
+          FQDN_FOLDERS + ".UnclassifiedFastQFolder",
+          FQDN_FOLDERS + ".OtherReportsFolder",
+          FQDN_FOLDERS + ".BasecallingFolder"
+  ]
+
+  private OxfordNanoporeExperiment(String sampleId, List<OxfordNanoporeMeasurement> measurements) {
+    this.measurements = Objects.requireNonNull(measurements, "measurements must not be null")
+    this.sampleId = Objects.requireNonNull(sampleId, "sampleId must not be null")
+  }
+
+  /**
+   * Static factory method that creates a new instance from a Oxford Nanopore sequencer output.
+   *
+   * @param Map nanoPoreSequencerOutput
+   * @return OxfordNanoporeExperiment A new instance of a nanopore experiment.
+   */
+  static OxfordNanoporeExperiment create(Map nanoPoreSequencerOutput) {
+    final String sampleId = parseQbicIdFromRootFolder(nanoPoreSequencerOutput)
+    final List<OxfordNanoporeMeasurement> measurements = parseMeasurements(nanoPoreSequencerOutput)
+    return new OxfordNanoporeExperiment(sampleId, measurements)
+  }
+
+  /**
+   * Provides a list of measurements contained within the experiment folder.
+   * @return
+   */
+  List<OxfordNanoporeMeasurement> getMeasurements() {
+    return this.measurements
+  }
+
+  @Override
+  String getSampleCode() {
+    return this.sampleId
+  }
+
+  /**
+   * Helper method that parses the QBiC identifier from the root folder name
+   */
+  private static String parseQbicIdFromRootFolder(Map nanoPoreSequencerOutput) {
+    def name = Objects.requireNonNull(nanoPoreSequencerOutput.get("name"), "The root folder must contain a name property.")
+    final def ids = SampleCodeFunctions.findAllQbicSampleCodes(name as String)
+    if (ids.isEmpty()) {
+      throw new IllegalArgumentException("No QBiC sample identifier found!")
     }
-
-    /**
-     * Static factory method that creates a new instance from a Oxford Nanopore sequencer output.
-     *
-     * @param Map nanoPoreSequencerOutput
-     * @return OxfordNanoporeExperiment A new instance of a nanopore experiment.
-     */
-    static OxfordNanoporeExperiment create(Map nanoPoreSequencerOutput) {
-        final String sampleId = parseQbicIdFromRootFolder(nanoPoreSequencerOutput)
-        final List<OxfordNanoporeMeasurement> measurements = parseMeasurements(nanoPoreSequencerOutput)
-        return new OxfordNanoporeExperiment(sampleId, measurements)
+    if (ids.size() > 1) {
+      throw new IllegalArgumentException("Name contained more than one valid sample id!")
     }
+    return ids.get(0)
+  }
 
-    /**
-     * Provides a list of measurements contained within the experiment folder.
-     * @return
-     */
-    List<OxfordNanoporeMeasurement> getMeasurements() {
-        return this.measurements
+  /**
+   * Helper method that creates the measurements from the sequencer output
+   */
+  private static List<OxfordNanoporeMeasurement> parseMeasurements(Map nanoPoreSequencerOutput) {
+    final def measurements = []
+    Objects.requireNonNull(nanoPoreSequencerOutput.get("children"), "The root folder must contain at least one measurement folder.")
+    nanoPoreSequencerOutput.get("children").each { Map measurementItem ->
+      def name = measurementItem.get("name") as String
+      def relativePath = measurementItem.get("path") as String
+      def children = parseMeasurementItems(measurementItem.get("children") as List)
+      def metadata = measurementItem.get("metadata") as Map
+      measurements.add(new OxfordNanoporeMeasurement(name, relativePath, children, metadata))
     }
+    return measurements
+  }
 
-    @Override
-    String getSampleCode() {
-        return this.sampleId
-    }
+  /*
+   * Helper method that creates a list of mixed DataFolders and DataFiles instances
+   */
 
-    /**
-     * Helper method that parses the QBiC identifier from the root folder name
-     */
-    private static String parseQbicIdFromRootFolder(Map nanoPoreSequencerOutput) {
-        def name = Objects.requireNonNull(nanoPoreSequencerOutput.get("name"), "The root folder must contain a name property.")
-        final def ids = SampleCodeFunctions.findAllQbicSampleCodes(name as String)
-        if (ids.isEmpty()) {
-            throw new IllegalArgumentException("No QBiC sample identifier found!")
+  private static List<?> parseMeasurementItems(List<Map> items) {
+    final def children = []
+    items.each { item ->
+      {
+        if (item.get(FILEKEY)) {
+          // Lets try to parse it as a subclass of a DataFile
+          DataFile putativeFile = parseFile(item)
+          children.add(putativeFile)
         }
-        if (ids.size() > 1) {
-            throw new IllegalArgumentException("Name contained more than one valid sample id!")
+        if (item.get(FOLDERKEY)) {
+          // Lets try to parse it as a subclass of a DataFile
+          DataFolder putativeFolder = parseFolder(item)
+          children.add(putativeFolder)
         }
-        return ids.get(0)
+      }
     }
+    return children
+  }
 
-    /**
-     * Helper method that creates the measurements from the sequencer output
-     */
-    private static List<OxfordNanoporeMeasurement> parseMeasurements(Map nanoPoreSequencerOutput) {
-        final def measurements = []
-        Objects.requireNonNull(nanoPoreSequencerOutput.get("children"), "The root folder must contain at least one measurement folder.")
-        nanoPoreSequencerOutput.get("children").each { Map measurementItem ->
-            def name = measurementItem.get("name") as String
-            def relativePath = measurementItem.get("path") as String
-            def children = parseMeasurementItems(measurementItem.get("children") as List)
-            def metadata = measurementItem.get("metadata") as Map
-            measurements.add(new OxfordNanoporeMeasurement(name, relativePath, children, metadata))
-        }
-        return measurements
+  /*
+   * Helper method that creates a DataFile instance from a map
+   */
+
+  private static DataFile parseFile(Map fileTree) throws IllegalArgumentException {
+    String name = fileTree.get("name")
+    String path = fileTree.get("path")
+    for (String nanoPoreFileType : nanoporeFileTypes) {
+      Class<?> c = Class.forName(nanoPoreFileType)
+      Method method = c.getDeclaredMethod("create", String.class, String.class)
+      try {
+        DataFile dataFile = method.invoke(null, name, path) as DataFile
+        return dataFile
+      } catch (InvocationTargetException e) {
+        // Do nothing as we need to try out all specialisations that extend the
+        // DataFile class
+      }
     }
-
-    /*
-     * Helper method that creates a list of mixed DataFolders and DataFiles instances
-     */
-
-    private static List<?> parseMeasurementItems(List<Map> items) {
-        final def children = []
-        items.each { item ->
-            try {
-                // Lets try to parse it as a subclass of a DataFile
-                def putativeFile = parseFile(item)
-                children.add(putativeFile)
-            } catch (IllegalArgumentException e) {
-                // In this case, no DataFile could be created, try to convert to a DataFolder then
-                def putativeFolder = parseFolder(item)
-                children.add(putativeFolder)
-            }
-        }
-        return children
+    try {
+      String fileSuffix = fileTree.get("file_type")
+      // Since the file structure is highly variable we want to allow for unknown files to be included in the experiment
+      OptionalFile optionalFile = OptionalFile.create(name, path, fileSuffix)
+      return optionalFile
+    } catch (Exception ignored) {
+      throw new IllegalArgumentException("File $name with path $path is not a valid Data File")
     }
+  }
 
-    /*
-     * Helper method that creates a DataFile instance from a map
-     */
+  /*
+   * Helper method that creates a DataFolder instance from a map
+   */
 
-    private static DataFile parseFile(Map fileTree) throws IllegalArgumentException {
-        def name = fileTree.get("name")
-        def path = fileTree.get("path")
-        for (String nanoPoreFileType : nanoporeFileTypes) {
-            Class<?> c = Class.forName(nanoPoreFileType)
-            Method method = c.getDeclaredMethod("create", String.class, String.class)
-            try {
-                DataFile dataFile = method.invoke(null, name, path) as DataFile
-                return dataFile
-            } catch (InvocationTargetException e) {
-                // Do nothing as we need to try out all specialisations that extend the
-                // DataFile class
-            }
-        }
-        // If we cannot create a DataFile object at all, throw an exception
-        throw new IllegalArgumentException("File $name with path $path is of unknown Oxford Nanopore file type.")
+  private static DataFolder parseFolder(Map fileTree) throws IllegalArgumentException {
+    String name = fileTree.get("name") as String
+    String path = fileTree.get("path") as String
+    def children = parseChildren(fileTree.get("children") as List)
+
+    for (String nanoPoreFolderType : nanoporeFolderTypes) {
+      Method method = determineMethod(Class.forName(nanoPoreFolderType))
+      Optional<DataFolder> folder = tryToCreateDataFolder(method, name, path, children)
+      if (folder.isPresent()) {
+        return folder.get()
+      }
     }
-
-    /*
-     * Helper method that creates a DataFolder instance from a map
-     */
-
-    private static DataFolder parseFolder(Map fileTree) throws IllegalArgumentException {
-        def name = fileTree.get("name") as String
-        def path = fileTree.get("path") as String
-        def children = parseChildren(fileTree.get("children") as List)
-
-        for (String nanoPoreFolderType : nanoporeFolderTypes) {
-            Method method = determineMethod(Class.forName(nanoPoreFolderType))
-            Optional<DataFolder> folder = tryToCreateDataFolder(method, name, path, children)
-            if (folder.isPresent()) {
-                return folder.get()
-            }
-        }
-        // If we reach this point, no DataFolder could be created based on the known folder types
-        // in life.qbic.datamodel.datasets.datastructure.folders.nanopore.*
-        throw new IllegalArgumentException("Folder $name with path $path is of unknown Oxford Nanopore folder type.")
+    // Since the file structure is highly variable we want to allow for unknown folders to be included in the experiment
+    try {
+      OptionalFolder optionalFolder = OptionalFolder.create(name, path, children)
+      return optionalFolder
+    } catch (Exception ignored) {
+      throw new IllegalArgumentException("Folder $name with path $path is not a valid Data Folder")
     }
+  }
 
-    /*
-     * Helper method that tries to create a DataFolder instance
-     * based on the DataFolder's different static factory create methods.
-     * As we do not know, whether a folder element is another typed folder
-     * such as FastQPassFolder or a named folder such as Fast5Folder, we have to
-     * try and fail.
-     */
+  /*
+   * Helper method that tries to create a DataFolder instance
+   * based on the DataFolder's different static factory create methods.
+   * As we do not know, whether a folder element is another typed folder
+   * such as FastQPassFolder or a named folder such as Fast5Folder, we have to
+   * try and fail.
+   */
 
-    private static Optional<DataFolder> tryToCreateDataFolder(Method method,
-                                                              String name,
-                                                              String relativePath,
-                                                              List children) {
-        Optional<DataFolder> folder = Optional.empty()
-        try {
-            // Try typed folder
-            def dataFolder = method.invoke(null, relativePath, children) as DataFolder
-            folder = Optional.of(dataFolder)
-        } catch (InvocationTargetException e) {
-            // Do nothing
-        } catch (IllegalArgumentException e) {
-            try {
-                // Try named folder
-                def dataFolder = method.invoke(null, name, relativePath, children) as DataFolder
-                folder = Optional.of(dataFolder)
-            } catch (InvocationTargetException e2) {
-                // Do nothing
-            }
-        }
-        return folder
+  private static Optional<DataFolder> tryToCreateDataFolder(Method method,
+                                                            String name,
+                                                            String relativePath,
+                                                            List children) {
+    Optional<DataFolder> folder = Optional.empty()
+    try {
+      // Try typed folder
+      def dataFolder = method.invoke(null, relativePath, children) as DataFolder
+      folder = Optional.of(dataFolder)
+    } catch (InvocationTargetException e) {
+      // Do nothing
+    } catch (IllegalArgumentException e) {
+      try {
+        // Try named folder
+        def dataFolder = method.invoke(null, name, relativePath, children) as DataFolder
+        folder = Optional.of(dataFolder)
+      } catch (InvocationTargetException e2) {
+        // Do nothing
+      }
     }
+    return folder
+  }
 
-    /*
-     * Helper method that parses the children of a folder.
-     */
+  /*
+   * Helper method that parses the children of a folder.
+   */
 
-    private static List parseChildren(List<Map> children) {
-        def parsedChildren = []
-        children.each { Map unknownChild ->
-            try {
-                def child = parseFile(unknownChild)
-                parsedChildren.add(child)
-            } catch (IllegalArgumentException e) {
-                // We do not capture the second parse call, as we want to fail the parsing at this point.
-                // This means that we ultimately found a child of unknown type, which should
-                // break the parsing.
-                def child = parseFolder(unknownChild)
-                parsedChildren.add(child)
-            }
-        }
-        return parsedChildren
+  private static List parseChildren(List<Map> children) {
+    def parsedChildren = []
+    children.each { Map unknownChild ->
+      if (unknownChild.get(FILEKEY)) {
+        def child = parseFile(unknownChild)
+        parsedChildren.add(child)
+      }
+      if (unknownChild.get(FOLDERKEY)) {
+        // We do not capture the second parse call, as we want to fail the parsing at this point.
+        // This means that we ultimately found a child of unknown type, which should
+        // break the parsing.
+        def child = parseFolder(unknownChild)
+        parsedChildren.add(child)
+      }
     }
+    return parsedChildren
+  }
 
-    /*
-    Determines the correct static create method for a data folder.
-     */
+  /*
+  Determines the correct static create method for a data folder.
+   */
 
-    private static Method determineMethod(Class c) {
-        def method
-        try {
-            // named folder (i.e. Fast5Folder)
-            method = c.getDeclaredMethod("create", String.class, String.class, List.class)
-        } catch (NoSuchMethodException e) {
-            // typed folder (i.e. FastQPassFolder)
-            method = c.getDeclaredMethod("create", String.class, List.class)
-        }
-        return method
+  private static Method determineMethod(Class c) {
+    def method
+    try {
+      // named folder (i.e. Fast5Folder)
+      method = c.getDeclaredMethod("create", String.class, String.class, List.class)
+    } catch (NoSuchMethodException e) {
+      // typed folder (i.e. FastQPassFolder)
+      method = c.getDeclaredMethod("create", String.class, List.class)
     }
+    return method
+  }
 }

--- a/src/main/groovy/life/qbic/datamodel/datasets/OxfordNanoporeExperiment.groovy
+++ b/src/main/groovy/life/qbic/datamodel/datasets/OxfordNanoporeExperiment.groovy
@@ -17,14 +17,14 @@ import java.lang.reflect.Method
 final class OxfordNanoporeExperiment implements ExperimentFolder {
 
   // Fully qualified domain name of the nanopore folder structure package
-  private final static String FQDN_FOLDERS = "life.qbic.datamodel.datasets.datastructure.folders.nanopore"
+  private static final String FQDN_FOLDERS = "life.qbic.datamodel.datasets.datastructure.folders.nanopore"
   // Fully qualified domain name of the nanopore file structure package
-  private final static String FQDN_FILES = "life.qbic.datamodel.datasets.datastructure.files.nanopore"
+  private static final String FQDN_FILES = "life.qbic.datamodel.datasets.datastructure.files.nanopore"
 
   //Unique key in fileTreeMap identifying a child as a file
-  private final static String FILEKEY = "file_type"
+  private static final String FILEKEY = "file_type"
   //Unique key in fileTreeMap identifyng a child as a folder
-  private final static String FOLDERKEY = "children"
+  private static final String FOLDERKEY = "children"
 
   private final List<OxfordNanoporeMeasurement> measurements
 
@@ -245,9 +245,6 @@ final class OxfordNanoporeExperiment implements ExperimentFolder {
         parsedChildren.add(child)
       }
       if (unknownChild.get(FOLDERKEY)) {
-        // We do not capture the second parse call, as we want to fail the parsing at this point.
-        // This means that we ultimately found a child of unknown type, which should
-        // break the parsing.
         def child = parseFolder(unknownChild)
         parsedChildren.add(child)
       }

--- a/src/main/groovy/life/qbic/datamodel/datasets/datastructure/files/nanopore/OptionalFile.groovy
+++ b/src/main/groovy/life/qbic/datamodel/datasets/datastructure/files/nanopore/OptionalFile.groovy
@@ -1,0 +1,29 @@
+package life.qbic.datamodel.datasets.datastructure.files.nanopore
+
+import life.qbic.datamodel.datasets.datastructure.files.DataFile
+
+/**
+ * Unspecific OptionalFile used to store unexpected file n the nanopore registration
+ *
+ * The high variety of the nanopore datasets registered made an optional all-purpose Datafile structure necessary.
+ *
+ */
+class OptionalFile extends DataFile {
+
+  protected OptionalFile() {}
+
+  protected OptionalFile(String name, String relativePath, String fileType) {
+    super(name, relativePath, fileType)
+  }
+
+  /**
+   * Creates a new instance of a OptionalFile object
+   * @param name The name of the file
+   * @param relativePath The relative path of the file
+   * @param fileType The suffix specifying the file type of the file
+   * @return A new instance of a OptionalFile object
+   */
+  static OptionalFile create(String name, String relativePath, String fileType) {
+    return new OptionalFile(name, relativePath, fileType)
+  }
+}

--- a/src/main/groovy/life/qbic/datamodel/datasets/datastructure/files/nanopore/OptionalFile.groovy
+++ b/src/main/groovy/life/qbic/datamodel/datasets/datastructure/files/nanopore/OptionalFile.groovy
@@ -3,7 +3,7 @@ package life.qbic.datamodel.datasets.datastructure.files.nanopore
 import life.qbic.datamodel.datasets.datastructure.files.DataFile
 
 /**
- * Unspecific OptionalFile used to store unexpected file n the nanopore registration
+ * Unspecific OptionalFile used to store unexpected file in the nanopore registration
  *
  * The high variety of the nanopore datasets registered made an optional all-purpose Datafile structure necessary.
  *

--- a/src/main/groovy/life/qbic/datamodel/datasets/datastructure/folders/nanopore/OptionalFolder.groovy
+++ b/src/main/groovy/life/qbic/datamodel/datasets/datastructure/folders/nanopore/OptionalFolder.groovy
@@ -1,0 +1,29 @@
+package life.qbic.datamodel.datasets.datastructure.folders.nanopore
+
+import life.qbic.datamodel.datasets.datastructure.folders.DataFolder
+
+/**
+ * Unspecific Optional Folder used to store unexpected folders in the nanopore registration
+ *
+ * The high variety of the nanopore datasets registered made an optional all-purpose Datafolder structure necessary.
+ *
+ */
+class OptionalFolder extends DataFolder {
+
+  protected OptionalFolder() {}
+
+  protected OptionalFolder(String name, String relativePath, List children) {
+    super(name, relativePath, children)
+  }
+
+  /**
+   * Creates a new instance of a OptionalFolder object
+   * @param relativePath The relative path of the folder
+   * @param children A list with child elements of unknown type of the folder
+   * @return A new instance of a OptionalFolder object
+   */
+  static OptionalFolder create(String name, String relativePath, List<?> children) {
+    new OptionalFolder(name, relativePath, children)
+  }
+
+}

--- a/src/main/groovy/life/qbic/datamodel/instruments/OxfordNanoporeInstrumentOutputMinimal.groovy
+++ b/src/main/groovy/life/qbic/datamodel/instruments/OxfordNanoporeInstrumentOutputMinimal.groovy
@@ -1,0 +1,19 @@
+package life.qbic.datamodel.instruments
+
+
+/**
+ * Represents the Nanopore instrument output data structure schema.
+ *
+ * The original schema is defined in as resource and is
+ * referenced here, wrapped in a Groovy class for reference
+ * in applications that want to validate the instrument
+ * output structure against the schema.
+ */
+class OxfordNanoporeInstrumentOutputMinimal {
+
+  private static final String SCHEMA_PATH = "/schemas/nanopore-instrument-output_minimal_schema.json"
+
+  static InputStream getSchemaAsStream() {
+    return OxfordNanoporeInstrumentOutputMinimal.getResourceAsStream(SCHEMA_PATH)
+  }
+}

--- a/src/main/resources/schemas/nanopore-instrument-output_minimal_schema.json
+++ b/src/main/resources/schemas/nanopore-instrument-output_minimal_schema.json
@@ -1,0 +1,515 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "http://qbic.life/nanopore-instrument-output_minimal.schema.json",
+  "title": "Nanopore Instrument Output minimal",
+  "description": "Describes in which form PromethION/MinION sequenced Nanopore data is received from the medical genetics lab. To be used if no other schema fits the description and ensure that the minimal necessary files are provided",
+  "definitions": {
+    "folder": {
+      "description": "Describes a folder",
+      "type": "object",
+      "required": [
+        "name",
+        "path",
+        "children"
+      ],
+      "properties": {
+        "name": {
+          "description": "Folder name",
+          "type": "string",
+          "minLength": 1
+        },
+        "path": {
+          "description": "relative folderpath",
+          "type": "string",
+          "minLength": 1
+        },
+        "children": {
+          "description": "Describes files and/or sub-folders if existent",
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/folder"
+              },
+              {
+                "$ref": "#/definitions/file"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "file": {
+      "description": "Describes a file",
+      "type": "object",
+      "required": [
+        "name",
+        "path",
+        "file_type"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "file_type": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "qbic_code": {
+      "description": "Describes a QBiC code used as a prefix",
+      "type": "string",
+      "pattern": "Q\\w{4}\\d{3}[A-X][A-X0-9].*"
+    },
+    "barcoded_folder": {
+      "description": "folder starting with qbic barcode prefix",
+      "allOf": [
+        {
+          "$ref": "#/definitions/folder"
+        },
+        {
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/qbic_code"
+            }
+          }
+        }
+      ]
+    },
+    "fast5_file": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/file"
+        },
+        {
+          "properties": {
+            "file_type": {
+              "pattern": "fast5"
+            }
+          }
+        }
+      ]
+    },
+    "fastqgz_file": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/file"
+        },
+        {
+          "properties": {
+            "file_type": {
+              "pattern": "fastq.gz"
+            }
+          }
+        }
+      ]
+    },
+    "fastq_file": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/file"
+        },
+        {
+          "properties": {
+            "file_type": {
+              "pattern": "fastq"
+            }
+          }
+        }
+      ]
+    },
+    "unclassified_folder": {
+      "description": "folder containing unassigned read file(s)",
+      "allOf": [
+        {
+          "$ref": "#/definitions/folder"
+        },
+        {
+          "properties": {
+            "name": {
+              "pattern": "unclassified"
+            }
+          }
+        }
+      ]
+    },
+    "fast5_unclassified_folder": {
+      "description": "folder containing fast5 data from a pooling experiment, that could not be assigned to one of the known samples",
+      "allOf": [
+        {
+          "$ref": "#/definitions/unclassified_folder"
+        },
+        {
+          "properties": {
+            "children": {
+              "items": {
+                "$ref": "#/definitions/fast5_file"
+              },
+              "minItems": 0
+            }
+          }
+        }
+      ]
+    },
+    "fastq_unclassified_folder": {
+      "description": "folder containing fastq and/or fastq.gz data from a pooling experiment, that could not be assigned to one of the known samples",
+      "allOf": [
+        {
+          "$ref": "#/definitions/unclassified_folder"
+        },
+        {
+          "properties": {
+            "children": {
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/fastqgz_file"
+                  },
+                  {
+                    "$ref": "#/definitions/fastq_file"
+                  }
+                ]
+              },
+              "minItems": 0
+            }
+          }
+        }
+      ]
+    },
+    "fast5_subfolder": {
+      "description": "folder containing fast5 data from a single sample (only when pooling is used)",
+      "allOf": [
+        {
+          "$ref": "#/definitions/barcoded_folder"
+        },
+        {
+          "properties": {
+            "children": {
+              "items": {
+                "$ref": "#/definitions/fast5_file"
+              },
+              "minItems": 1
+            }
+          }
+        }
+      ]
+    },
+    "fast5_fail": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/folder"
+        },
+        {
+          "properties": {
+            "name": {
+              "pattern": "fast5_fail"
+            },
+            "children": {
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/fast5_subfolder"
+                  },
+                  {
+                    "$ref": "#/definitions/fast5_unclassified_folder"
+                  },
+                  {
+                    "$ref": "#/definitions/fast5_file"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "fast5_pass": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/folder"
+        },
+        {
+          "properties": {
+            "name": {
+              "pattern": "fast5_pass"
+            },
+            "children": {
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/fast5_subfolder"
+                  },
+                  {
+                    "$ref": "#/definitions/fast5_unclassified_folder"
+                  },
+                  {
+                    "$ref": "#/definitions/fast5_file"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "fastq_fail": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/folder"
+        },
+        {
+          "properties": {
+            "name": {
+              "pattern": "fastq_fail"
+            },
+            "children": {
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/fastq_subfolder"
+                  },
+                  {
+                    "$ref": "#/definitions/fastq_unclassified_folder"
+                  },
+                  {
+                    "$ref": "#/definitions/fastqgz_file"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "fastq_pass": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/folder"
+        },
+        {
+          "properties": {
+            "name": {
+              "pattern": "fastq_pass"
+            },
+            "children": {
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/fastq_subfolder"
+                  },
+                  {
+                    "$ref": "#/definitions/fastq_unclassified_folder"
+                  },
+                  {
+                    "$ref": "#/definitions/fastqgz_file"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "fastq_subfolder": {
+      "description": "folder containing gzipped fastq data from a single sample (only when pooling is used)",
+      "allOf": [
+        {
+          "$ref": "#/definitions/barcoded_folder"
+        },
+        {
+          "properties": {
+            "children": {
+              "items": {
+                "$ref": "#/definitions/fastqgz_file"
+              },
+              "minItems": 1
+            }
+          }
+        }
+      ]
+    },
+    "optional_folder": {
+      "description": "Folder not expected in the current schemas but not invalidating the minimal datastructure required",
+      "allOf": [
+        {
+          "$ref": "#/definitions/folder"
+        },
+        {
+          "properties": {}
+        }
+      ]
+    },
+    "measurements": {
+      "description": "Top folder generated by the facility, containing one or more timestamped measurements",
+      "allOf": [
+        {
+          "$ref": "#/definitions/barcoded_folder"
+        },
+        {
+          "properties": {
+            "children": {
+              "items": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/measurement"
+                  }
+                ]
+              },
+              "minItems": 1
+            }
+          }
+        }
+      ]
+    },
+    "measurement": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/folder"
+        },
+        {
+          "properties": {
+            "name": {
+              "pattern": "\\d{4}(0?[1-9]|1[012])(0?[1-9]|[12][0-9]|3[01])_([01][0-9]|2[0-3])([0-5][0-9]).*",
+              "description": "Name of measurement subfolder. Starts with date and time of measurement."
+            },
+            "children": {
+              "uniqueItems": true,
+              "properties": {
+                "fastq_fail": {
+                  "$ref": "#/definitions/fastq_fail"
+                },
+                "fastq_pass": {
+                  "$ref": "#/definitions/fastq_pass"
+                },
+                "fast5_pass": {
+                  "$ref": "#/definitions/fast5_pass"
+                },
+                "fast5_fail": {
+                  "$ref": "#/definitions/fast5_fail"
+                },
+                "optional_folder": {
+                  "$ref": "#/definitions/optional_folder"
+                },
+                "barcode_alignment": {
+                  "$ref": "#/definitions/barcode_alignment_log"
+                },
+                "final_summary_log": {
+                  "$ref": "#/definitions/final_summary_log"
+                },
+                "report_md_log": {
+                  "$ref": "#/definitions/report_md_log"
+                },
+                "sequencing_summary_log": {
+                  "$ref": "#/definitions/sequencing_summary_log"
+                },
+                "optional_file": {
+                  "$ref": "#/definitions/optional_file"
+                }
+              },
+              "required": [
+                "fastq_fail",
+                "fastq_pass",
+                "fast5_pass",
+                "fast5_fail",
+                "barcode_alignment_log",
+                "final_summary_log",
+                "report_md_log",
+                "sequencing_summary_log"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "barcode_alignment_log": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/file"
+        },
+        {
+          "properties": {
+            "name": {
+              "pattern": "barcode_alignment_.*"
+            },
+            "file_type": {
+              "pattern": "tsv"
+            }
+          }
+        }
+      ]
+    },
+    "final_summary_log": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/file"
+        },
+        {
+          "properties": {
+            "name": {
+              "pattern": "final_summary_.*"
+            },
+            "file_type": {
+              "pattern": "txt"
+            }
+          }
+        }
+      ]
+    },
+    "report_md_log": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/file"
+        },
+        {
+          "properties": {
+            "name": {
+              "pattern": "report_.*"
+            },
+            "file_type": {
+              "pattern": "md"
+            }
+          }
+        }
+      ]
+    },
+    "sequencing_summary_log": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/file"
+        },
+        {
+          "properties": {
+            "name": {
+              "pattern": "sequencing_summary_.*"
+            },
+            "file_type": {
+              "pattern": "txt"
+            }
+          }
+        }
+      ]
+    },
+    "optional_file": {
+      "description": "File not expected in the current schemas but not invalidating the minimal datastructure required",
+      "allOf": [
+        {
+          "$ref": "#/definitions/file"
+        },
+        {
+          "properties": {}
+        }
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/measurements"
+    }
+  ]
+}

--- a/src/main/resources/schemas/nanopore-instrument-output_minimal_schema.json
+++ b/src/main/resources/schemas/nanopore-instrument-output_minimal_schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "http://qbic.life/nanopore-instrument-output_minimal.schema.json",
   "title": "Nanopore Instrument Output minimal",
   "description": "Describes in which form PromethION/MinION sequenced Nanopore data is received from the medical genetics lab. To be used if no other schema fits the description and ensure that the minimal necessary files are provided",
@@ -379,45 +379,35 @@
               "description": "Name of measurement subfolder. Starts with date and time of measurement."
             },
             "children": {
+              "type": "array",
               "uniqueItems": true,
-              "properties": {
-                "fastq_fail": {
-                  "$ref": "#/definitions/fastq_fail"
-                },
-                "fastq_pass": {
-                  "$ref": "#/definitions/fastq_pass"
-                },
-                "fast5_pass": {
-                  "$ref": "#/definitions/fast5_pass"
-                },
-                "fast5_fail": {
-                  "$ref": "#/definitions/fast5_fail"
-                },
-                "optional_folder": {
-                  "$ref": "#/definitions/optional_folder"
-                },
-                "final_summary_log": {
-                  "$ref": "#/definitions/final_summary_log"
-                },
-                "report_md_log": {
-                  "$ref": "#/definitions/report_md_log"
-                },
-                "sequencing_summary_log": {
-                  "$ref": "#/definitions/sequencing_summary_log"
-                },
-                "optional_file": {
-                  "$ref": "#/definitions/optional_file"
-                }
+              "minItems": 7,
+              "contains": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/fastq_fail"
+                  },
+                  {
+                    "$ref": "#/definitions/fastq_pass"
+                  },
+                  {
+                    "$ref": "#/definitions/fast5_pass"
+                  },
+                  {
+                    "$ref": "#/definitions/fast5_fail"
+                  },
+                  {
+                    "$ref": "#/definitions/final_summary_log"
+                  },
+                  {
+                    "$ref": "#/definitions/report_md_log"
+                  },
+                  {
+                    "$ref": "#/definitions/sequencing_summary_log"
+                  }
+                ]
               },
-              "required": [
-                "fastq_fail",
-                "fastq_pass",
-                "fast5_pass",
-                "fast5_fail",
-                "final_summary_log",
-                "report_md_log",
-                "sequencing_summary_log"
-              ]
+              "minContains": 7
             }
           }
         }

--- a/src/main/resources/schemas/nanopore-instrument-output_minimal_schema.json
+++ b/src/main/resources/schemas/nanopore-instrument-output_minimal_schema.json
@@ -376,11 +376,10 @@
           "properties": {
             "name": {
               "pattern": "\\d{4}(0?[1-9]|1[012])(0?[1-9]|[12][0-9]|3[01])_([01][0-9]|2[0-3])([0-5][0-9]).*",
-              "description": "Name of measurement subfolder. Starts with date and time of measurement."
+              "description": "Name of measurement subfolder. Starts with date and time of measurement e.g. 20200122_1217..."
             },
             "children": {
               "type": "array",
-              "uniqueItems": true,
               "minItems": 7,
               "contains": {
                 "oneOf": [
@@ -407,7 +406,8 @@
                   }
                 ]
               },
-              "minContains": 7
+              "minContains": 7,
+              "uniqueItems": true
             }
           }
         }

--- a/src/main/resources/schemas/nanopore-instrument-output_minimal_schema.json
+++ b/src/main/resources/schemas/nanopore-instrument-output_minimal_schema.json
@@ -396,9 +396,6 @@
                 "optional_folder": {
                   "$ref": "#/definitions/optional_folder"
                 },
-                "barcode_alignment": {
-                  "$ref": "#/definitions/barcode_alignment_log"
-                },
                 "final_summary_log": {
                   "$ref": "#/definitions/final_summary_log"
                 },
@@ -417,28 +414,10 @@
                 "fastq_pass",
                 "fast5_pass",
                 "fast5_fail",
-                "barcode_alignment_log",
                 "final_summary_log",
                 "report_md_log",
                 "sequencing_summary_log"
               ]
-            }
-          }
-        }
-      ]
-    },
-    "barcode_alignment_log": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/file"
-        },
-        {
-          "properties": {
-            "name": {
-              "pattern": "barcode_alignment_.*"
-            },
-            "file_type": {
-              "pattern": "tsv"
             }
           }
         }

--- a/src/test/groovy/life/qbic/datamodel/datasets/datastructure/OxfordNanoporeExperimentSpec.groovy
+++ b/src/test/groovy/life/qbic/datamodel/datasets/datastructure/OxfordNanoporeExperimentSpec.groovy
@@ -41,6 +41,7 @@ class OxfordNanoporeExperimentSpec extends Specification {
      */
     @Shared
     Map extendedDataStructureWithReportsFolderV4
+
     /**
      * Map that that stores the Oxford Nanopore folder structure
      * according to the schema containing unclassified read information
@@ -52,7 +53,13 @@ class OxfordNanoporeExperimentSpec extends Specification {
      * according to the schema containing pooled samples read information
      */
     @Shared
-    Map minimalWorkingPooledDataStructure
+    Map pooledDataStructure
+
+    @Shared
+    Map minimalDataStructure
+
+    @Shared
+    Map minimalDataStructurePooled
 
     def setupSpec() {
         def folder = "nanopore/"
@@ -75,7 +82,13 @@ class OxfordNanoporeExperimentSpec extends Specification {
         unclassifiedWorkingDataStructure = (Map) new JsonSlurper().parse(stream)
         // read in pooled example
         stream = Thread.currentThread().getContextClassLoader().getResourceAsStream(folder+"valid-example-pooled.json")
-        minimalWorkingPooledDataStructure = (Map) new JsonSlurper().parse(stream)
+        pooledDataStructure = (Map) new JsonSlurper().parse(stream)
+        // read in minimal required example
+        stream = Thread.currentThread().getContextClassLoader().getResourceAsStream(folder+"valid-minimal-structure.json")
+        minimalDataStructure = (Map) new JsonSlurper().parse(stream)
+        // read in minimal required pooled example
+        stream = Thread.currentThread().getContextClassLoader().getResourceAsStream(folder+"valid-minimal-structure-pooled.json")
+        minimalDataStructurePooled = (Map) new JsonSlurper().parse(stream)
         stream.close()
     }
 
@@ -149,9 +162,37 @@ class OxfordNanoporeExperimentSpec extends Specification {
         assert measurements[0].asicTemp == "32.631687"
     }
 
+    def "Create sample Oxford Nanopore experiment successfully for the minimal required structure"() {
+        given:
+        final def example = minimalDataStructure
+
+        when:
+        final def experiment = OxfordNanoporeExperiment.create(example)
+        final def measurements = experiment.getMeasurements()
+
+        then:
+        assert experiment.sampleCode == "QABCD001AB"
+        assert measurements.size() == 1
+        assert measurements[0].asicTemp == "32.631687"
+    }
+
+    def "Create sample Oxford Nanopore experiment successfully for the minimal required pooled structure"() {
+        given:
+        final def example = minimalDataStructurePooled
+
+        when:
+        final def experiment = OxfordNanoporeExperiment.create(example)
+        final def measurements = experiment.getMeasurements()
+
+        then:
+        assert experiment.sampleCode == "QABCD001AB"
+        assert measurements.size() == 1
+        assert measurements[0].asicTemp == "32.631687"
+    }
+
     def "Create a simple pooled Oxford Nanopore experiment successfully"() {
         given:
-        final def example = minimalWorkingPooledDataStructure
+        final def example = pooledDataStructure
 
         when:
         final def experiment = OxfordNanoporeExperiment.create(example)

--- a/src/test/resources/nanopore/valid-minimal-structure-pooled.json
+++ b/src/test/resources/nanopore/valid-minimal-structure-pooled.json
@@ -1,0 +1,349 @@
+{
+  "name": "QABCD001AB_E12A345a01_PAE12345",
+  "path": "./",
+  "children": [
+    {
+      "name": "20200122_1217_1-A1-B1-PAE12345_1234567a",
+      "metadata": {
+        "adapter": "flongle",
+        "asic_temp": "32.631687",
+        "base_caller": "Guppy",
+        "base_caller_version": "3.2.8+bd67289",
+        "device_type": "promethion",
+        "flow_cell_id": "PAE26306",
+        "flow_cell_product_code": "FLO-PRO002",
+        "flow_cell_position": "2-A3-D3",
+        "hostname": "PCT0094",
+        "protocol": "sequencing/sequencing_PRO002_DNA:FLO-PRO002:SQK-LSK109:True",
+        "started": "2020-02-11T15:52:10.465982+01:00"
+      },
+      "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a",
+      "children": [
+        {
+          "name": "report_.md",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/report_.md",
+          "file_type": "md"
+        },
+        {
+          "name": "final_summary_.txt",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/final_summary_.txt",
+          "file_type": "txt"
+        },
+        {
+          "name": "sequencing_summary_.txt",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/sequencing_summary_.txt",
+          "file_type": "txt"
+        },
+        {
+          "name": "barcode_alignment_.tsv",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/barcode_alignment_.tsv",
+          "file_type": "tsv"
+        },
+        {
+          "name": "additional_file_.new",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/additional_file_.new",
+          "file_type": "new"
+        },
+        {
+          "name": "not_relevant_file_.wow",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/not_relevant_file_.wow",
+          "file_type": "wow"
+        },
+        {
+          "name": "unknown_folder",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/unknown_folder",
+          "children": [
+            {
+              "name": "unknown_child_folder",
+              "path": "20200122_1217_1-A1-B1-PAE12345_1234567a/unknown_folder/unknown_child_folder",
+              "children": [
+                {
+                  "name": "unknown_file_.new",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/unknown_folder/unknown_child_folder/unknown_file_.new",
+                  "file_type": "new"
+                }
+              ]
+            },
+            {
+              "name": "unknown_file_.new",
+              "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/unknown_folder/unknown_file_.new",
+              "file_type": "new"
+            }
+          ]
+        },
+        {
+          "name": "fastq_pass",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass",
+          "children": [
+            {
+              "name": "QABCD001AB",
+              "path": "20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/QABCD001AB",
+              "children": [
+                {
+                  "name": "myfile3.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/QABCD001AB/myfile3.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile2.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/QABCD001AB/myfile2.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile4.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/QABCD001AB/myfile4.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile5.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/QABCD001AB/myfile5.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile1.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/QABCD001AB/myfile1.fastq.gz",
+                  "file_type": "fastq.gz"
+                }
+              ]
+            },
+            {
+              "name": "QABCD002CD",
+              "path": "20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/QABCD002CD",
+              "children": [
+                {
+                  "name": "myfile3.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/QABCD002CD/myfile3.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile2.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/QABCD002CD/myfile2.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile4.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/QABCD002CD/myfile4.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile5.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/QABCD002CD/myfile5.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile1.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/QABCD002CD/myfile1.fastq.gz",
+                  "file_type": "fastq.gz"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "fastq_fail",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail",
+          "children": [
+            {
+              "name": "QABCD001AB",
+              "path": "20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/QABCD001AB",
+              "children": [
+                {
+                  "name": "myfile3.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/QABCD001AB/myfile3.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile2.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/QABCD001AB/myfile2.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile4.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/QABCD001AB/myfile4.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile5.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/QABCD001AB/myfile5.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile1.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/QABCD001AB/myfile1.fastq.gz",
+                  "file_type": "fastq.gz"
+                }
+              ]
+            },
+            {
+              "name": "QABCD002CD",
+              "path": "20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/QABCD002CD",
+              "children": [
+                {
+                  "name": "myfile3.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/QABCD002CD/myfile3.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile2.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/QABCD002CD/myfile2.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile4.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/QABCD002CD/myfile4.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile5.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/QABCD002CD/myfile5.fastq.gz",
+                  "file_type": "fastq.gz"
+                },
+                {
+                  "name": "myfile1.fastq.gz",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/QABCD002CD/myfile1.fastq.gz",
+                  "file_type": "fastq.gz"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "fast5_fail",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail",
+          "children": [
+            {
+              "name": "QABCD001AB",
+              "path": "20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/QABCD001AB",
+              "children": [
+                {
+                  "name": "myfile3.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/QABCD001AB/myfile3.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile2.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/QABCD001AB/myfile2.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile4.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/QABCD001AB/myfile4.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile5.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/QABCD001AB/myfile5.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile1.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/QABCD001AB/myfile1.fast5",
+                  "file_type": "fast5"
+                }
+              ]
+            },
+            {
+              "name": "QABCD002CD",
+              "path": "20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/QABCD002CD",
+              "children": [
+                {
+                  "name": "myfile3.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/QABCD002CD/myfile3.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile2.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/QABCD002CD/myfile2.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile4.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/QABCD002CD/myfile4.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile5.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/QABCD002CD/myfile5.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile1.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/QABCD002CD/myfile1.fast5",
+                  "file_type": "fast5"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "fast5_pass",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass",
+          "children": [
+            {
+              "name": "QABCD001AB",
+              "path": "20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/QABCD001AB",
+              "children": [
+                {
+                  "name": "myfile3.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/QABCD001AB/myfile3.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile2.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/QABCD001AB/myfile2.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile4.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/QABCD001AB/myfile4.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile5.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/QABCD001AB/myfile5.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile1.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/QABCD001AB/myfile1.fast5",
+                  "file_type": "fast5"
+                }
+              ]
+            },
+            {
+              "name": "QABCD002CD",
+              "path": "20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/QABCD002CD",
+              "children": [
+                {
+                  "name": "myfile3.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/QABCD002CD/myfile3.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile2.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/QABCD002CD/myfile2.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile4.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/QABCD002CD/myfile4.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile5.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/QABCD002CD/myfile5.fast5",
+                  "file_type": "fast5"
+                },
+                {
+                  "name": "myfile1.fast5",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/QABCD002CD/myfile1.fast5",
+                  "file_type": "fast5"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/nanopore/valid-minimal-structure-pooled.json
+++ b/src/test/resources/nanopore/valid-minimal-structure-pooled.json
@@ -35,11 +35,6 @@
           "file_type": "txt"
         },
         {
-          "name": "barcode_alignment_.tsv",
-          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/barcode_alignment_.tsv",
-          "file_type": "tsv"
-        },
-        {
           "name": "additional_file_.new",
           "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/additional_file_.new",
           "file_type": "new"

--- a/src/test/resources/nanopore/valid-minimal-structure.json
+++ b/src/test/resources/nanopore/valid-minimal-structure.json
@@ -1,0 +1,201 @@
+{
+  "name": "QABCD001AB_E12A345a01_PAE12345",
+  "path": "./",
+  "children": [
+    {
+      "name": "20200122_1217_1-A1-B1-PAE12345_1234567a",
+      "metadata": {
+        "adapter": "flongle",
+        "asic_temp": "32.631687",
+        "base_caller": "Guppy",
+        "base_caller_version": "3.2.8+bd67289",
+        "device_type": "promethion",
+        "flow_cell_id": "PAE26306",
+        "flow_cell_product_code": "FLO-PRO002",
+        "flow_cell_position": "2-A3-D3",
+        "hostname": "PCT0094",
+        "protocol": "sequencing/sequencing_PRO002_DNA:FLO-PRO002:SQK-LSK109:True",
+        "started": "2020-02-11T15:52:10.465982+01:00"
+      },
+      "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a",
+      "children": [
+        {
+          "name": "report_.md",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/report_.md",
+          "file_type": "md"
+        },
+        {
+          "name": "final_summary_.txt",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/final_summary_.txt",
+          "file_type": "txt"
+        },
+        {
+          "name": "sequencing_summary_.txt",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/sequencing_summary_.txt",
+          "file_type": "txt"
+        },
+        {
+          "name": "barcode_alignment_.tsv",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/barcode_alignment_.tsv",
+          "file_type": "tsv"
+        },
+        {
+          "name": "additional_file_.new",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/additional_file_.new",
+          "file_type": "new"
+        },
+        {
+          "name": "not_relevant_file_.wow",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/not_relevant_file_.wow",
+          "file_type": "wow"
+        },
+        {
+          "name": "unknown_folder",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/unknown_folder",
+          "children": [
+            {
+              "name": "unknown_child_folder",
+              "path": "20200122_1217_1-A1-B1-PAE12345_1234567a/unknown_folder/unknown_child_folder",
+              "children": [
+                {
+                  "name": "unknown_file_.new",
+                  "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/unknown_folder/unknown_child_folder/unknown_file_.new",
+                  "file_type": "new"
+                }
+              ]
+            },
+            {
+              "name": "unknown_file_.new",
+              "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/unknown_folder/unknown_file_.new",
+              "file_type": "new"
+            }
+          ]
+        },
+        {
+          "name": "fastq_pass",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass",
+          "children": [
+            {
+              "name": "myfile3.fastq.gz",
+              "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/myfile3.fastq.gz",
+              "file_type": "fastq.gz"
+            },
+            {
+              "name": "myfile2.fastq.gz",
+              "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/myfile2.fastq.gz",
+              "file_type": "fastq.gz"
+            },
+            {
+              "name": "myfile4.fastq.gz",
+              "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/myfile4.fastq.gz",
+              "file_type": "fastq.gz"
+            },
+            {
+              "name": "myfile5.fastq.gz",
+              "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/myfile5.fastq.gz",
+              "file_type": "fastq.gz"
+            },
+            {
+              "name": "myfile1.fastq.gz",
+              "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_pass/myfile1.fastq.gz",
+              "file_type": "fastq.gz"
+            }
+          ]
+        },
+        {
+          "name": "fastq_fail",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/",
+          "children": [
+            {
+              "name": "myfile3.fastq.gz",
+              "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/myfile3.fastq.gz",
+              "file_type": "fastq.gz"
+            },
+            {
+              "name": "myfile2.fastq.gz",
+              "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/myfile2.fastq.gz",
+              "file_type": "fastq.gz"
+            },
+            {
+              "name": "myfile4.fastq.gz",
+              "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/myfile4.fastq.gz",
+              "file_type": "fastq.gz"
+            },
+            {
+              "name": "myfile5.fastq.gz",
+              "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/myfile5.fastq.gz",
+              "file_type": "fastq.gz"
+            },
+            {
+              "name": "myfile.fastq.gz",
+              "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fastq_fail/myfile.fastq.gz",
+              "file_type": "fastq.gz"
+            }
+          ]
+        },
+        {
+          "name": "fast5_fail",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/",
+          "children": [
+            {
+              "name": "myfile2.fast5",
+              "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/myfile2.fast5",
+              "file_type": "fast5"
+            },
+            {
+              "name": "myfile4.fast5",
+              "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/myfile4.fast5",
+              "file_type": "fast5"
+            },
+            {
+              "name": "myfile3.fast5",
+              "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/myfile3.fast5",
+              "file_type": "fast5"
+            },
+            {
+              "name": "myfile5.fast5",
+              "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/myfile5.fast5",
+              "file_type": "fast5"
+            },
+            {
+              "name": "myfile.fast5",
+              "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_fail/myfile.fast5",
+              "file_type": "fast5"
+            }
+          ]
+        },
+        {
+          "name": "fast5_pass",
+          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/",
+          "children": [
+            {
+              "name": "myfile2.fast5",
+              "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/myfile2.fast5",
+              "file_type": "fast5"
+            },
+            {
+              "name": "myfile4.fast5",
+              "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/myfile4.fast5",
+              "file_type": "fast5"
+            },
+            {
+              "name": "myfile3.fast5",
+              "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/myfile3.fast5",
+              "file_type": "fast5"
+            },
+            {
+              "name": "myfile5.fast5",
+              "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/myfile5.fast5",
+              "file_type": "fast5"
+            },
+            {
+              "name": "myfile.fast5",
+              "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/fast5_pass/myfile.fast5",
+              "file_type": "fast5"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/nanopore/valid-minimal-structure.json
+++ b/src/test/resources/nanopore/valid-minimal-structure.json
@@ -35,11 +35,6 @@
           "file_type": "txt"
         },
         {
-          "name": "barcode_alignment_.tsv",
-          "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/barcode_alignment_.tsv",
-          "file_type": "tsv"
-        },
-        {
           "name": "additional_file_.new",
           "path": "./20200122_1217_1-A1-B1-PAE12345_1234567a/additional_file_.new",
           "file_type": "new"


### PR DESCRIPTION
**What was changed**
This PR introduces a schema and example json for checking if the minimal required files for a nanopore data registration are within a provided dataset. 
Additionally it adapts the `OxfordNanoporeExperiment` generation to not fail if an unknown file or folder is found but include them as `OptionalFile` and `OptionalFolder` in the datastructure to allow for variations within the provided datastructure.

**Background information**
As of now the minimum required folders are: 

- FASTQ_FAIL
- FASTQ_PASS
- FAST5_FAIL
- FAST5_PASS

While the minimum required files are: 

- final_summary.txt (We extract metadata from this file)
- report.md (We extract metadata from this file)
- sequencing_summary.txt (Both Labs)

**Open Questions**
Due to the new constraints, the previously defined schemas and datafiles/Datafolders are ALL now unnecessary and could be deleted, since as soon as the minimal required files are provided the `OxfordNanoporeExperiment` is created and can be parsed.
The only reason for keeping multiple schemas could be if the distinction between the files in the OxfordnanoporeExperiment class is necessary (e.g. for accessing metadata within the files).
However this is only the case for the `final_summary.txt` file and the `report.md` file as of yet. 